### PR TITLE
Added support for MPEG-SD interactivity extensions

### DIFF
--- a/Runtime/Scripts/ActionActivate.cs
+++ b/Runtime/Scripts/ActionActivate.cs
@@ -1,0 +1,63 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Handle the activation state of one or multiple gameObject
+    /// </summary>
+    public class ActionActivate : MonoBehaviour, IMpegInteractivityAction
+    {
+        public float Delay => m_Delay;
+
+        private GameObject[] m_Objects;
+        private bool m_ActivationStatus;
+        private float m_Delay;
+
+        public void Init(Schema.Action action)
+        {
+            m_Objects = VirtualSceneGraph.GetGameObjectsFromIndexes(action.nodes);
+            m_ActivationStatus = action.activationStatus == ActivationStatus.DISABLED;
+            m_Delay = action.delay;
+        }
+
+        public void Invoke()
+        {
+            if(Delay > 0.0f)
+            {
+                StartCoroutine(StartWithDelay(Delay));
+            }
+            else
+            {
+                Execute();
+            }
+        }
+
+        private void Execute()
+        {
+            for (int i = 0; i < m_Objects.Length; i++)
+            {
+                m_Objects[i].SetActive(m_ActivationStatus);
+            }
+        }
+
+        private IEnumerator StartWithDelay(float _time)
+        {
+            yield return new WaitForSeconds(_time);
+            Execute();
+        }
+    }
+}

--- a/Runtime/Scripts/ActionActivate.cs.meta
+++ b/Runtime/Scripts/ActionActivate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03f7584abf8b3f344b5b9a65618c1b1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/ActionAnimation.cs
+++ b/Runtime/Scripts/ActionAnimation.cs
@@ -1,0 +1,80 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System.Collections;
+using GLTFast.Schema;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Handle the Animation state of an object
+    /// </summary>
+    public class ActionAnimation : MonoBehaviour, IMpegInteractivityAction
+    {
+        public float Delay => m_Delay;
+        private float m_Delay;
+
+        private AnimationControl m_AnimationControl;
+        private Animation m_TargetAnimation;
+        private Animation m_PauseFrame;
+        private AnimationClip m_Clip;
+
+        public void Init(Schema.Action action)
+        {
+            m_Delay = action.delay;
+            m_AnimationControl = action.animationControl;
+            m_Clip = VirtualSceneGraph.GetAnimationClipFromIndex(action.animation);
+            m_TargetAnimation = VirtualSceneGraph.GetAnimationFromClipIndex(action.animation);
+        }
+
+        public void Invoke()
+        {
+            if (Delay > 0.0f)
+            {
+                StartCoroutine(StartWithDelay(Delay));
+            }
+            else
+            {
+                Execute();
+            }
+        }
+
+        private void Execute()
+        {
+            switch (m_AnimationControl)
+            {
+                case AnimationControl.ANIMATION_PLAY:
+                    m_TargetAnimation.clip = m_Clip;
+                    m_TargetAnimation.Play();
+                    break;
+
+                case AnimationControl.ANIMATION_PAUSE:
+                    throw new System.NotImplementedException("ANIMATION_PAUSE not implemented");
+
+                case AnimationControl.ANIMATION_RESUME:
+                    m_TargetAnimation.Play();
+                    break;
+
+                case AnimationControl.ANIMATION_STOP:
+                    m_TargetAnimation.Stop();
+                    break;
+            }
+        }
+
+        
+        private IEnumerator StartWithDelay(float _time)
+        {
+            yield return new WaitForSeconds(_time);
+            Execute();
+        }
+    }
+}

--- a/Runtime/Scripts/ActionAnimation.cs.meta
+++ b/Runtime/Scripts/ActionAnimation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1ae94010c848e144bcd4ec19c18e64f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/ActionBlock.cs
+++ b/Runtime/Scripts/ActionBlock.cs
@@ -52,6 +52,11 @@ namespace GLTFast
             }
         }
 
+        public void Unlock()
+        {
+            m_IsBlock = false;
+        }
+
         public void Invoke()
         {
             if (Delay > 0.0f)

--- a/Runtime/Scripts/ActionBlock.cs
+++ b/Runtime/Scripts/ActionBlock.cs
@@ -1,0 +1,86 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System.Collections;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Lock any object or set of objects at a given position/rotation
+    /// </summary>
+    public class ActionBlock : MonoBehaviour, IMpegInteractivityAction
+    {
+        public float Delay => m_Delay;
+        private float m_Delay;
+        private bool m_IsBlock = false;
+
+        private Vector3[] m_BlockedPosition;
+        private Quaternion[] m_BlockedRotation;
+        private Vector3[] m_BlockedScale;
+        private GameObject[] m_LockedObjects;
+
+        public void Init(Schema.Action action)
+        {
+            m_LockedObjects = VirtualSceneGraph.GetGameObjectsFromIndexes(action.nodes);
+            m_BlockedPosition = new Vector3[action.nodes.Length];
+            m_BlockedRotation = new Quaternion[action.nodes.Length];
+            m_BlockedScale = new Vector3[action.nodes.Length];
+            m_Delay = action.delay;
+        }
+
+        private void Update()
+        {
+            if (!m_IsBlock)
+            {
+                return;
+            }
+
+            for (int i = 0; i < m_LockedObjects.Length; i++)
+            {
+                m_LockedObjects[i].transform.position = m_BlockedPosition[i];
+                m_LockedObjects[i].transform.rotation = m_BlockedRotation[i];
+                m_LockedObjects[i].transform.localScale = m_BlockedScale[i];
+            }
+        }
+
+        public void Invoke()
+        {
+            if (Delay > 0.0f)
+            {
+                StartCoroutine(StartWithDelay(Delay));
+            }
+            else
+            {
+                Execute();
+            }
+        }
+
+        private void Execute()
+        {
+            m_IsBlock = true;
+
+            // Cache values 
+            for (int i = 0; i < m_LockedObjects.Length; i++)
+            {
+                m_BlockedPosition[i] = m_LockedObjects[i].transform.position;
+                m_BlockedRotation[i] = m_LockedObjects[i].transform.rotation;
+                m_BlockedScale[i] = m_LockedObjects[i].transform.localScale;
+            }
+        }
+
+        private IEnumerator StartWithDelay(float _time)
+        {
+            yield return new WaitForSeconds(_time);
+            Execute();
+        }
+    }
+}

--- a/Runtime/Scripts/ActionBlock.cs.meta
+++ b/Runtime/Scripts/ActionBlock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64228c085cb9cd64697be9fa2abe6275
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/ActionManipulate.cs
+++ b/Runtime/Scripts/ActionManipulate.cs
@@ -1,0 +1,213 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System;
+using System.Collections;
+using UnityEngine;
+#if USE_NEW_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Manipulates the transformation of one or multiple gameObjects
+    /// </summary>
+    public class ActionManipulate : MonoBehaviour, IMpegInteractivityAction
+    {
+        public float Delay => m_Delay;
+        private float m_Delay;
+        private Vector3 m_Axises;
+        private GameObject[] m_Targets;
+        private Schema.Action.ManipulateActionType m_CurrentManipulateType;
+#if USE_NEW_INPUT_SYSTEM
+        private InputAction m_InputAction;
+        private object m_ReadInputValue;
+#endif
+        private bool m_IsInputPerformed;
+        private Vector3 m_Position;
+        private UnityEngine.Camera Camera
+        {
+            get
+            {
+                if (m_Camera == null)
+                {
+                    m_Camera = FindObjectOfType<UnityEngine.Camera>();
+                }
+                return m_Camera;
+            }
+        }
+        private UnityEngine.Camera m_Camera;
+
+        public void Init(Schema.Action action)
+        {
+            string binding = UserInputSceneTrigger.GetBindingFromUserInputDescription(action.userInputDescription);
+            m_InputAction = new InputAction(action.userInputDescription, binding: binding);
+            m_InputAction.performed += OnInputPerformed;
+            m_InputAction.canceled += OnInputCanceled;
+            m_InputAction.Enable();
+
+            m_Axises = action.axis;
+            m_Targets = VirtualSceneGraph.GetGameObjectsFromIndexes(action.nodes);
+            m_Delay = action.delay;
+            m_CurrentManipulateType = action.manipulateActionType;
+            m_Camera = UnityEngine.Camera.main;
+        }
+
+        private void OnInputCanceled(InputAction.CallbackContext _cbk)
+        {
+            m_IsInputPerformed = false;
+            m_ReadInputValue = _cbk.ReadValueAsObject();
+        }
+
+        private void OnInputPerformed(InputAction.CallbackContext _cbk)
+        {
+            m_IsInputPerformed = true;
+            m_ReadInputValue = _cbk.ReadValueAsObject();
+        }
+
+        public void Invoke()
+        {
+            if (Delay > 0.0f)
+            {
+                StartCoroutine(StartWithDelay(Delay));
+            }
+            else
+            {
+                Execute();
+            }
+        }
+
+        private void Execute()
+        {
+            if (!m_IsInputPerformed)
+            {
+                return;
+            }
+
+            switch(m_CurrentManipulateType)
+            {
+                case Schema.Action.ManipulateActionType.ACTION_MANIPULATE_FREE: ManipulateFree(); break;
+                case Schema.Action.ManipulateActionType.ACTION_MANIPULATE_ROTATE: ManipulateRotate(); break;
+                case Schema.Action.ManipulateActionType.ACTION_MANIPULATE_SCALE: ManipulateScale(); break;
+                case Schema.Action.ManipulateActionType.ACTION_MANIPULATE_SLIDE: ManipulateSlide(); break;
+                case Schema.Action.ManipulateActionType.ACTION_MANIPULATE_TRANSLATE: ManipulateTranslate(); break;
+            }
+        }
+
+        private void ManipulateFree()
+        {
+            ManipulateTranslate();
+            ManipulateRotate();
+            ManipulateScale();
+        }
+
+        private void ManipulateSlide()
+        {
+            ManipulateTranslate();
+        }
+
+        private void ManipulateTranslate()
+        {
+            // Get the type of the read input value first
+            Type _t = m_ReadInputValue.GetType();
+
+            if (_t == typeof(Vector3))
+            {
+                Vector3 _position = (Vector3)m_ReadInputValue;
+                MovePosition(_position);
+            }
+            if (_t == typeof(Vector2))
+            {
+                // When 2D, we assume that this is a cursor, and doing
+                // the manipulation restricted to screen space
+                Vector3 _position = (Vector2)m_ReadInputValue;
+                _position.z = 1.0f;
+                Vector3 _screenPos = Camera.ScreenToWorldPoint(_position);
+                MovePosition(_screenPos);
+            }
+        }
+
+        private void ManipulateScale()
+        {
+            // Get the type of the read input value first
+            Type _t = m_ReadInputValue.GetType();
+
+            if (_t == typeof(Vector3))
+            {
+                Vector3 _scale = (Vector3)m_ReadInputValue;
+                MoveScale(_scale);
+            }
+        }
+
+        private void ManipulateRotate()
+        {
+            // Get the type of the read input value first
+            Type _t = m_ReadInputValue.GetType();
+
+            if (_t == typeof(Vector3))
+            {
+                Vector3 _euler = (Vector3)m_ReadInputValue;
+                Quaternion _rotation = Quaternion.Euler(_euler);
+                MoveRotation(_rotation);
+            }
+            if (_t == typeof(Quaternion))
+            {
+                Quaternion _rotation = (Quaternion)m_ReadInputValue;
+                MoveRotation(_rotation);
+            }
+        }
+
+        private void MovePosition(Vector3 _pos)
+        {
+            if(m_Axises != Vector3.zero)
+            {
+                // Move restricted to axis
+                _pos.x *= m_Axises.x;
+                _pos.y *= m_Axises.y;
+                _pos.z *= m_Axises.z;
+            }
+            
+            for (int i = 0; i < m_Targets.Length; i++)
+            {
+                // Move unrestricted
+                m_Targets[i].transform.position = _pos;
+            }
+        }
+
+        private void MoveRotation(Quaternion _rot)
+        {
+            if (m_Axises != Vector3.zero)
+            {
+                // TODO: Rotate restricted to axis X, Y, Z
+            }
+
+            for (int i = 0; i < m_Targets.Length; i++)
+            {
+                m_Targets[i].transform.rotation = _rot;
+            }
+        }
+
+        private void MoveScale(Vector3 _sca)
+        {
+            for(int i = 0; i < m_Targets.Length; i++)
+            {
+                m_Targets[i].transform.localScale = _sca;
+            }
+        }
+
+        private IEnumerator StartWithDelay(float _time)
+        {
+            yield return new WaitForSeconds(_time);
+            Execute();
+        }
+    }
+}

--- a/Runtime/Scripts/ActionManipulate.cs
+++ b/Runtime/Scripts/ActionManipulate.cs
@@ -12,9 +12,7 @@
 using System;
 using System.Collections;
 using UnityEngine;
-#if USE_NEW_INPUT_SYSTEM
 using UnityEngine.InputSystem;
-#endif
 
 namespace GLTFast
 {
@@ -28,10 +26,8 @@ namespace GLTFast
         private Vector3 m_Axises;
         private GameObject[] m_Targets;
         private Schema.Action.ManipulateActionType m_CurrentManipulateType;
-#if USE_NEW_INPUT_SYSTEM
         private InputAction m_InputAction;
         private object m_ReadInputValue;
-#endif
         private bool m_IsInputPerformed;
         private Vector3 m_Position;
         private UnityEngine.Camera Camera

--- a/Runtime/Scripts/ActionManipulate.cs.meta
+++ b/Runtime/Scripts/ActionManipulate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfca5c3aa78c9ce40aaf3930d24c952a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/ActionMedia.cs
+++ b/Runtime/Scripts/ActionMedia.cs
@@ -1,0 +1,55 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Handle the execution of media
+    /// </summary>
+    public class ActionMedia : MonoBehaviour, IMpegInteractivityAction
+    {
+        public float Delay => m_Delay;
+        private float m_Delay;
+        public void Init(Schema.Action action)
+        {
+            m_Delay = action.delay;
+            Debug.Log("TODO: Init ActionMedia");
+        }
+
+        public void Invoke()
+        {
+            if (Delay > 0.0f)
+            {
+                StartCoroutine(StartWithDelay(Delay));
+            }
+            else
+            {
+                Execute();
+            }
+        }
+
+        private void Execute()
+        {
+            // VirtualSceneGraph.root.extensions.MPEG_media.media[0].alternatives[0].uri;
+            Debug.LogError("TODO: Execute ActionMedia");
+        }
+
+        private IEnumerator StartWithDelay(float _time)
+        {
+            yield return new WaitForSeconds(_time);
+            Execute();
+        }
+    }
+}

--- a/Runtime/Scripts/ActionMedia.cs.meta
+++ b/Runtime/Scripts/ActionMedia.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff6cfda85e67cba4b82bc05790f3f8eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/ActionSetAvatar.cs
+++ b/Runtime/Scripts/ActionSetAvatar.cs
@@ -1,0 +1,43 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System;
+using UnityEngine;
+
+namespace GLTFast
+{
+    public class ActionSetAvatar : MonoBehaviour, IMpegInteractivityAction
+    {
+        public float Delay => throw new NotImplementedException();
+
+        public void Init(Schema.Action action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Invoke()
+        {
+            if (Delay > 0.0f)
+            {
+                TimeUtils.instance.StartTimer(Delay, Execute);
+            }
+            else
+            {
+                Execute();
+            }
+        }
+
+        private void Execute()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Runtime/Scripts/ActionSetAvatar.cs.meta
+++ b/Runtime/Scripts/ActionSetAvatar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a997df478f857604eacdedfbe2e5cbb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/ActionSetHaptic.cs
+++ b/Runtime/Scripts/ActionSetHaptic.cs
@@ -1,0 +1,43 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System;
+using UnityEngine;
+
+namespace GLTFast
+{
+    public class ActionSetHaptic : MonoBehaviour, IMpegInteractivityAction
+    {
+        public float Delay => throw new NotImplementedException();
+
+        public void Init(Schema.Action action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Invoke()
+        {
+            if (Delay > 0.0f)
+            {
+                TimeUtils.instance.StartTimer(Delay, Execute);
+            }
+            else
+            {
+                Execute();
+            }
+        }
+
+        private void Execute()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Runtime/Scripts/ActionSetHaptic.cs.meta
+++ b/Runtime/Scripts/ActionSetHaptic.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9353f1c988e0a154ba34e7552ca5680c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/ActionSetMaterial.cs
+++ b/Runtime/Scripts/ActionSetMaterial.cs
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Assign a material to one or multiple gameObject
+    /// </summary>
+    public class ActionSetMaterial : MonoBehaviour, IMpegInteractivityAction
+    {
+        public float Delay => m_Delay;
+
+        private GameObject[] m_Objects;
+        private Material m_TargetMaterial;
+        private float m_Delay;
+
+        public void Init(Schema.Action action)
+        {
+            m_Objects = VirtualSceneGraph.GetGameObjectsFromIndexes(action.nodes);
+            m_TargetMaterial = VirtualSceneGraph.GetMaterialFromIndex(action.material);
+            m_Delay = action.delay;
+        }
+
+        public void Invoke()
+        {
+            if (Delay > 0.0f)
+            {
+                StartCoroutine(StartWithDelay(Delay));
+            }
+            else
+            {
+                Execute();
+            }
+        }
+
+        private void Execute()
+        {
+            for(int i = 0; i < m_Objects.Length; i++)
+            {
+                m_Objects[i].GetComponent<Renderer>().material = m_TargetMaterial;
+            }
+        }
+
+        private IEnumerator StartWithDelay(float _time)
+        {
+            yield return new WaitForSeconds(_time);
+            Execute();
+        }
+    }
+}

--- a/Runtime/Scripts/ActionSetMaterial.cs.meta
+++ b/Runtime/Scripts/ActionSetMaterial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 953480f4ec49ee24684b0b77067451f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/ActionTransform.cs
+++ b/Runtime/Scripts/ActionTransform.cs
@@ -26,7 +26,14 @@ namespace GLTFast
 
         public void Init(Schema.Action action)
         {
-            m_TargetMatrix = action.transform;
+            // Fill the target matrix
+            m_TargetMatrix = new Matrix4x4(
+                new Vector4(action.transform[0], action.transform[4], action.transform[8], action.transform[12]),
+                new Vector4(action.transform[1], action.transform[5], action.transform[9], action.transform[13]),
+                new Vector4(action.transform[2], action.transform[6], action.transform[10], action.transform[14]),
+                new Vector4(action.transform[3], action.transform[7], action.transform[11], action.transform[15])
+            );
+
             m_Targets = new GameObject[action.nodes.Length];
 
             for(int i = 0; i < action.nodes.Length; i++)

--- a/Runtime/Scripts/ActionTransform.cs
+++ b/Runtime/Scripts/ActionTransform.cs
@@ -1,0 +1,68 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Set transform to a node or a set of nodes
+    /// </summary>
+    public class ActionTransform : MonoBehaviour, IMpegInteractivityAction
+    {
+        private Matrix4x4 m_TargetMatrix;
+        private GameObject[] m_Targets;
+        public float Delay => throw new NotImplementedException();
+
+        public void Init(Schema.Action action)
+        {
+            m_TargetMatrix = action.transform;
+            m_Targets = new GameObject[action.nodes.Length];
+
+            for(int i = 0; i < action.nodes.Length; i++)
+            {
+                GameObject _obj = VirtualSceneGraph.GetGameObjectFromIndex(action.nodes[i]);
+                m_Targets[i] = _obj;
+            }
+        }
+
+        public void Invoke()
+        {
+            if (Delay > 0.0f)
+            {
+                StartCoroutine(StartWithDelay(Delay));
+            }
+            else
+            {
+                Execute();
+            }
+        }
+
+        private void Execute()
+        {
+            for(int i = 0; i < m_Targets.Length; i++)
+            {
+                Vector3 _targetPos = m_TargetMatrix.GetPosition();
+                Quaternion _targetRot = m_TargetMatrix.rotation;
+                m_Targets[i].transform.position = _targetPos;
+                m_Targets[i].transform.rotation = _targetRot;
+            }
+        }
+
+        private IEnumerator StartWithDelay(float _time)
+        {
+            yield return new WaitForSeconds(_time);
+            Execute();
+        }
+    }
+}

--- a/Runtime/Scripts/ActionTransform.cs.meta
+++ b/Runtime/Scripts/ActionTransform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e736ed2ba14f2242bb887844d192cc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Behavior.cs
+++ b/Runtime/Scripts/Behavior.cs
@@ -1,0 +1,216 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+using System.Collections.Generic;
+using System;
+using UnityEngine;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Main component of interactivity, handle the activation of triggers 
+    /// and invoke related actions
+    /// </summary>
+    public class Behavior : MonoBehaviour, IMpegInteractivityBehavior
+    {
+        private bool m_IsRunning = false;
+
+        private IMpegInteractivityTrigger[] m_Trigger;
+        private IMpegInteractivityAction[] m_Action;
+
+        public bool IsShared => m_Shared;
+        private bool m_Shared;
+
+        [NonSerialized] private char[] m_CombinationControlSymbols;
+        private const char AND_COMBINATION = '&';
+        private const char OR_COMBINATION = '|';
+        private const char XOR_COMBINATION = '^';
+        private const char NOT_COMBINATION = '!';
+        [NonSerialized] private bool[] m_CurrentFrameResultStates;
+
+        private bool m_LastFrameCombinationResult;
+        private bool m_HasEverEntered;
+        private bool m_HasEverExited;
+        private bool m_HasAlreadyEntered;
+
+        private Schema.Behavior.ActionsControl m_ActionControl;
+        private TriggerActivationControl m_TriggerActivationControl;
+        private IMpegInteractivityAction m_InterruptAction;
+
+        private List<System.Action> m_GameEngineActions;
+
+        public void InitializeBehavior(Schema.Behavior bhv)
+        {
+            // Cache trigger control
+            m_TriggerActivationControl = bhv.triggersActivationControl;
+
+            // Get behavior triggers instances
+            m_Trigger = new IMpegInteractivityTrigger[bhv.triggers.Length];
+            for (int i = 0; i < bhv.triggers.Length; i++)
+            {
+                int trigIndex = bhv.triggers[i];
+                m_Trigger[i] = VirtualSceneGraph.GetTriggerFromIndex(trigIndex);
+            }
+
+            // Get behavior actions instances
+            m_Action = new IMpegInteractivityAction[bhv.actions.Length];
+            for (int i = 0; i < bhv.actions.Length; i++)
+            {
+                int actIndex = bhv.actions[i];
+                m_Action[i] = VirtualSceneGraph.GetActionFromIndex(actIndex);
+            }
+
+            // TODO: Find a better way to evaluate expression
+            // Triggers combination control are written in a simple way: 'Trigger_index' 'Combination value'.
+            // Trigger indexes are defined like this: #1 #2 #3
+            // Combination value can be any bitwise operation like &, !, |, ^...
+            string _withoutDiese = bhv.triggersCombinationControl.Replace("#", string.Empty);
+            string _combination = Regex.Replace(_withoutDiese, @"[\d-]", string.Empty);
+
+            m_CombinationControlSymbols = _combination.ToCharArray();
+            m_CurrentFrameResultStates = new bool[bhv.triggers.Length];
+
+            // TODO: Add behavior priority
+
+            if (bhv.interruptAction.HasValue)
+            {
+                int index = bhv.interruptAction.Value;
+                m_InterruptAction = VirtualSceneGraph.GetActionFromIndex(index);
+            }
+
+            // Helper to get game object actions associated with mpeg actions
+            m_GameEngineActions = new List<System.Action>();
+            m_IsRunning = true;
+        }
+
+        public bool AreTriggersActived()
+        {
+            if(!m_IsRunning)
+            {
+                return false;
+            }
+
+            RunTriggers();
+
+            bool combinationResult = AreTriggersMeetCombinationControl();
+            TriggerActivationControl actControl = ProcessState(m_HasEverExited, m_HasEverEntered, m_LastFrameCombinationResult, combinationResult);
+            UpdateStates(actControl);
+            m_LastFrameCombinationResult = combinationResult;
+            return actControl == m_TriggerActivationControl;
+        }
+
+        private void RunTriggers()
+        {
+            // Run all triggers and store the boolean result in an array
+            for(int i = 0; i < m_Trigger.Length; i++)
+            {
+                m_CurrentFrameResultStates[i] = m_Trigger[i].MeetConditions();
+            }
+        }
+
+        private void UpdateStates(TriggerActivationControl actControl)
+        {
+            if(actControl == TriggerActivationControl.TRIGGER_ACTIVATE_FIRST_ENTER)
+            {
+                m_HasEverEntered = true;
+            }
+            else if(actControl == TriggerActivationControl.TRIGGER_ACTIVATE_FIRST_EXIT)
+            {
+                m_HasEverExited = true;
+            }
+        }
+
+        private bool AreTriggersMeetCombinationControl()
+        {
+            bool result = false;
+
+            // Compare pairs of booleans
+            for (int i = 0; i < m_CurrentFrameResultStates.Length; i++)
+            {
+                result = m_CurrentFrameResultStates[i];
+
+                if (i + 1 != m_CurrentFrameResultStates.Length)
+                {
+                    // Compare pairs of trigger results given a combination control symbol
+                    switch (m_CombinationControlSymbols[i])
+                    {
+                        case AND_COMBINATION: result = m_CurrentFrameResultStates[i] && m_CurrentFrameResultStates[i + 1]; break;
+                        case OR_COMBINATION: result = m_CurrentFrameResultStates[i] || m_CurrentFrameResultStates[i + 1]; break;
+                        case XOR_COMBINATION: result = m_CurrentFrameResultStates[i] ^= m_CurrentFrameResultStates[i + 1]; break;
+                        case NOT_COMBINATION: result = m_CurrentFrameResultStates[i] != m_CurrentFrameResultStates[i + 1]; break;
+                    }
+
+                    if (!result)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private TriggerActivationControl ProcessState(bool hasEverExited, bool hasEverEntered, bool lastCombinationResult, bool combinationResult)
+        {
+            TriggerActivationControl result = 0;
+
+            // Test activations
+            if (combinationResult) result = TriggerActivationControl.TRIGGER_ACTIVE_ON;
+            if (!combinationResult) result = TriggerActivationControl.TRIGGER_ACTIVATE_OFF;
+
+            if (combinationResult && !hasEverEntered) result = TriggerActivationControl.TRIGGER_ACTIVATE_FIRST_ENTER;
+            if (!lastCombinationResult && combinationResult) result = TriggerActivationControl.TRIGGER_ACTIVATE_EACH_ENTER;
+
+            if (!combinationResult && lastCombinationResult && !hasEverExited) result = TriggerActivationControl.TRIGGER_ACTIVATE_FIRST_EXIT;
+            if (!combinationResult && lastCombinationResult) result = TriggerActivationControl.TRIGGER_ACTIVATE_EACH_EXIT;
+
+            return result;
+        }
+
+        public void ActivateActions()
+        {
+            for(int i = 0; i < m_Action.Length; i++)
+            {
+                // TODO: Very costly operation - should implement efficient multithreading
+                if(m_ActionControl == Schema.Behavior.ActionsControl.PARALLEL)
+                {
+                    System.Action _act = () => m_Action[i].Invoke();
+                    ThreadStart _st = new ThreadStart(_act);
+                    Thread _thread = new Thread(_st);
+                    _thread.Start();
+                } 
+                else
+                {
+                    m_Action[i].Invoke();
+                }
+            }
+
+            for(int i = 0; i < m_GameEngineActions.Count; i++)
+            {
+                m_GameEngineActions[i].Invoke();
+            }
+        }
+
+        public void AddGameEngineAction(System.Action action)
+        {
+            m_GameEngineActions.Add(action);
+        }
+
+        public void Interrupt()
+        {
+            m_IsRunning = false;
+            m_InterruptAction?.Invoke();
+        }
+    }
+}

--- a/Runtime/Scripts/Behavior.cs
+++ b/Runtime/Scripts/Behavior.cs
@@ -142,6 +142,10 @@ namespace GLTFast
 
                 if (i + 1 != m_CurrentFrameResultStates.Length)
                 {
+                    if(i >= m_CombinationControlSymbols.Length) {
+                        break;
+                    }
+
                     // Compare pairs of trigger results given a combination control symbol
                     switch (m_CombinationControlSymbols[i])
                     {

--- a/Runtime/Scripts/Behavior.cs.meta
+++ b/Runtime/Scripts/Behavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4480842193608640ae1119fe9f09e98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/BehaviorController.cs
+++ b/Runtime/Scripts/BehaviorController.cs
@@ -1,0 +1,45 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GLTFast
+{
+    // Helper class to debug behaviors in editor
+    public class BehaviorController : MonoBehaviour
+    {
+        private List<IMpegInteractivityBehavior> m_Behaviors;
+
+        public void Init()
+        {
+            m_Behaviors = new List<IMpegInteractivityBehavior>();
+        }
+
+        public void AddBehavior(IMpegInteractivityBehavior bhv)
+        {
+            m_Behaviors.Add(bhv);
+        }
+
+        private void FixedUpdate()
+        {
+            for(int i = 0; i < m_Behaviors.Count; i++)
+            {
+                bool result = m_Behaviors[i].AreTriggersActived();
+                if(!result)
+                {
+                    continue;
+                }
+                m_Behaviors[i].ActivateActions();
+            }
+        }
+    }
+}

--- a/Runtime/Scripts/BehaviorController.cs.meta
+++ b/Runtime/Scripts/BehaviorController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5e33e0062cf2a7469404401a312f49a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/CollisionNodeTrigger.cs
+++ b/Runtime/Scripts/CollisionNodeTrigger.cs
@@ -86,10 +86,7 @@ namespace GLTFast
                 _meshCol.sharedMesh = _msh;
                 _meshCol.convex = true;
             }
-            if (node_info.isStatic)
-            {
-                m_Rb.isKinematic = true;
-            }
+            m_Rb.isKinematic = node_info.isStatic;
 
             if (node_info.usePhysics)
             {

--- a/Runtime/Scripts/CollisionNodeTrigger.cs
+++ b/Runtime/Scripts/CollisionNodeTrigger.cs
@@ -1,0 +1,139 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    ///  Represent the collision trigger at the node level
+    /// </summary>
+    public class CollisionNodeTrigger : MonoBehaviour
+    {
+        private bool m_HasInit = false;
+        private List<GameObject> m_Target;
+
+        public bool Collides => m_Collides;
+
+        private bool m_Collides = false;
+
+        private Rigidbody m_Rb;
+        private PhysicMaterial m_PhysicMat;
+
+        public void Init()
+        {
+            Debug.Log("Init collision detector");
+            if (!m_HasInit)
+            {
+                m_Target = new List<GameObject>();
+                m_HasInit = true;
+
+                // Check if this object has every components to perform collision
+                if (!gameObject.TryGetComponent(out m_Rb))
+                {
+                    m_Rb = gameObject.AddComponent<Rigidbody>();
+                }
+            }
+
+            // Set the default values for rigidbody
+            m_Rb.useGravity = false;
+            m_Rb.isKinematic = false;
+
+            // Assign default collider as mesh node (if set)
+            if (!TryGetComponent<Collider>(out Collider _col))
+            {
+                GLTFast.Schema.Node node = VirtualSceneGraph.GetNodeFromGameObject(gameObject);
+                int meshIndex = node.mesh;
+
+                if (meshIndex < 0)
+                {
+                    int nodeIndex = VirtualSceneGraph.GetNodeIndexFromGameObject(gameObject);
+                    Debug.LogWarning($"No mesh found for node index: {nodeIndex}. Assign default box collider");
+                    BoxCollider _collider = gameObject.AddComponent<BoxCollider>();
+                }
+                else
+                {
+                    MeshCollider _meshCol = gameObject.AddComponent<MeshCollider>();
+                    UnityEngine.Mesh _msh = VirtualSceneGraph.GetMeshFromIndex(meshIndex);
+                    _meshCol.sharedMesh = _msh;
+                    _meshCol.convex = true;
+                }
+            }
+
+            m_Rb.mass = 1.0f;
+        }
+
+        public void InitExtension(MpegNodeInteractivity.Trigger node_info)
+        {
+            Init();
+
+            if (!TryGetComponent(out Collider _col))
+            {
+                MeshCollider _meshCol = gameObject.AddComponent<MeshCollider>();
+                UnityEngine.Mesh _msh = VirtualSceneGraph.GetMeshFromIndex(node_info.collider);
+                _meshCol.sharedMesh = _msh;
+                _meshCol.convex = true;
+            }
+            if (node_info.isStatic)
+            {
+                m_Rb.isKinematic = true;
+            }
+
+            if (node_info.usePhysics)
+            {
+                m_Rb.useGravity = node_info.useGravity;
+                m_Rb.mass = node_info.mass;
+                if (TryGetComponent<MeshCollider>(out MeshCollider _meshCol))
+                {
+                    m_PhysicMat = new PhysicMaterial();
+                    m_PhysicMat.bounciness = node_info.restitution;
+                    m_PhysicMat.staticFriction = node_info.staticFriction;
+                    m_PhysicMat.dynamicFriction = node_info.dynamicFriction;
+                    _meshCol.material = m_PhysicMat;
+                }
+            }
+        }
+
+        public void AddTarget(GameObject obj)
+        {
+            if (!m_Target.Contains(obj) && obj != gameObject)
+            {
+                m_Target.Add(obj);
+            }
+        }
+
+        private void OnCollisionEnter(Collision other)
+        {
+            if (m_Target.Contains(other.gameObject))
+            {
+                m_Collides = true;
+            }
+        }
+
+        private void OnCollisionStay(Collision other)
+        {
+            if (m_Target.Contains(other.gameObject))
+            {
+                m_Collides = true;
+            }
+        }
+
+        private void OnCollisionExit(Collision other)
+        {
+            if (m_Target.Contains(other.gameObject))
+            {
+                m_Collides = false;
+            }
+        }
+    }
+}

--- a/Runtime/Scripts/CollisionNodeTrigger.cs
+++ b/Runtime/Scripts/CollisionNodeTrigger.cs
@@ -22,6 +22,7 @@ namespace GLTFast
     {
         private bool m_HasInit = false;
         private List<GameObject> m_Target;
+        private List<System.Action<GameObject>> m_GameEngineActions;
 
         public bool Collides => m_Collides;
 
@@ -43,6 +44,7 @@ namespace GLTFast
                 {
                     m_Rb = gameObject.AddComponent<Rigidbody>();
                 }
+                m_GameEngineActions = new List<System.Action<GameObject>>();
             }
 
             // Set the default values for rigidbody
@@ -117,6 +119,10 @@ namespace GLTFast
             if (m_Target.Contains(other.gameObject))
             {
                 m_Collides = true;
+                
+                for(int i = 0; i < m_GameEngineActions.Count; i++) {
+                    m_GameEngineActions[i]?.Invoke(other.gameObject);
+                }
             }
         }
 
@@ -125,6 +131,11 @@ namespace GLTFast
             if (m_Target.Contains(other.gameObject))
             {
                 m_Collides = true;
+
+                
+                for(int i = 0; i < m_GameEngineActions.Count; i++) {
+                    m_GameEngineActions[i]?.Invoke(other.gameObject);
+                }
             }
         }
 
@@ -134,6 +145,10 @@ namespace GLTFast
             {
                 m_Collides = false;
             }
+        }
+
+        public void AddCollisionCallback(System.Action<GameObject> _act) {
+            m_GameEngineActions.Add(_act);
         }
     }
 }

--- a/Runtime/Scripts/CollisionNodeTrigger.cs.meta
+++ b/Runtime/Scripts/CollisionNodeTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 29d22189fe7b0ca4a81f9b4bfcfe1f94
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/CollisionSceneTrigger.cs
+++ b/Runtime/Scripts/CollisionSceneTrigger.cs
@@ -1,0 +1,192 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    ///  Represent the collision trigger at the scene level
+    /// </summary>
+    public class CollisionSceneTrigger : MonoBehaviour, IMpegInteractivityTrigger
+    {
+        private List<CollisionNodeTrigger> m_CollisionsDetectors;
+        private bool m_Collides;
+
+        public void Init(Trigger trigger)
+        {
+            m_CollisionsDetectors = new List<CollisionNodeTrigger>();
+            if(trigger.nodes == null)
+            {
+                throw new System.Exception("No nodes detected in the collision trigger");
+            }
+
+            // Build the collisions normally
+            if(trigger.primitives == null)
+            {
+                // Add collision detectors by pairs
+                for (int i = 0; i < trigger.nodes.Length; i++)
+                {
+                    GameObject _obj = VirtualSceneGraph.GetGameObjectFromIndex(trigger.nodes[i]);
+                    CollisionNodeTrigger _collision = InitCollisionDetector(ref _obj);
+                    for (int j = i + 1; j < trigger.nodes.Length; j++)
+                    {
+                        GameObject _target = VirtualSceneGraph.GetGameObjectFromIndex(trigger.nodes[j]);
+                        CollisionNodeTrigger _col = InitCollisionDetector(ref _target);
+                        _collision.AddTarget(_target);
+                        _col.AddTarget(_obj);
+                    }
+                }
+            }
+            else
+            {
+                // Build collisions according to primitives
+                // The node itself isn't considered for collision
+                for(int i = 0; i < trigger.primitives.Length; i++)
+                {
+                    GameObject _primitive = CreateCollisionMeshFromPrimitive(trigger.primitives[i]);
+                    GameObject _node = VirtualSceneGraph.GetGameObjectFromIndex(trigger.nodes[i]);
+
+                    // Move the primitive according to the transformation matrix
+                    Matrix4x4 m = trigger.primitives[i].transformationMatrix;
+                    Vector3 _pos = m.GetPosition();
+                    Quaternion _rot = m.rotation;
+                    Vector3 _scale = Vector3.one;
+
+                    // Move the world position of the primitive according
+                    // to the associated primitive node
+                    _primitive.transform.position = _node.transform.position;
+                    _primitive.transform.localPosition = _pos;
+                    _primitive.transform.rotation = _rot;
+                    _primitive.transform.localScale = _scale;
+                    InitCollisionDetector(ref _primitive);
+                }
+            }
+        }
+
+        public bool MeetConditions()
+        {
+            return m_Collides;
+        }
+
+        private GameObject CreateCollisionMeshFromPrimitive(Trigger.Primitive primitive)
+        {
+            GameObject target = null;
+
+            switch (primitive.type)
+            {
+                case GLTFast.Schema.PrimitiveType.BV_CUBOID:
+                    target = PrimitivesHelper.PrimitivesCreateCuboidGameObject(primitive.width,
+                            primitive.height,
+                            primitive.length,
+                            primitive.centroid);
+                    break;
+
+                case Schema.PrimitiveType.BV_PLANE_REGION:
+                    target = PrimitivesHelper.PrimitivesCreatePlaneGameObject(primitive.width,
+                        primitive.height,
+                        primitive.centroid);
+                    break;
+
+                case Schema.PrimitiveType.BV_CYLINDER_REGION:
+                    target = PrimitivesHelper.PrimitivesCreateCylinderGameObject(primitive.radius,
+                        primitive.length,
+                        primitive.centroid);
+                    break;
+
+                case Schema.PrimitiveType.BV_CAPSULE_REGION:
+                    target = PrimitivesHelper.PrimitivesCreateCapsuleGameObject(primitive.radius,
+                        primitive.baseCentroid,
+                        primitive.topCentroid);
+                    break;
+
+                case Schema.PrimitiveType.BV_SPHEROID:
+                    target = PrimitivesHelper.PrimitivesCreateSpheroidGameObject(primitive.radius,
+                        primitive.centroid);
+                    break;
+            }
+
+            // Remove renderer from those meshes
+            target.GetComponent<Renderer>().enabled = false;
+            if (target.TryGetComponent(out Collider col))
+            {
+                Destroy(col);
+            }
+
+            // For now we are adding a mesh collider that will handle collisions for us
+            // TODO: Create a custom collision system that handles boundary
+            MeshCollider mshCol = target.AddComponent<MeshCollider>();
+            mshCol.sharedMesh = target.GetComponent<MeshFilter>().mesh;
+            mshCol.convex = true;
+
+            return target;
+        }
+
+        private CollisionNodeTrigger InitCollisionDetector(ref GameObject obj)
+        {
+            CollisionNodeTrigger _col = null;
+
+            Node _nd = VirtualSceneGraph.GetNodeFromGameObject(obj);
+
+            // Get the component if exists, else create it
+            if (obj.TryGetComponent<CollisionNodeTrigger>(out _col)) { }
+            else
+            {
+                CollisionNodeTrigger _collisionDetector = obj.AddComponent<CollisionNodeTrigger>();
+
+                // If the extensions exists, it means that we want to specify the collision detector behavior
+                if (_nd.extensions?.MPEG_node_interactivity != null)
+                {
+                    // Find if there is any collision trigger to be found
+                    for (int i = 0; i < _nd.extensions.MPEG_node_interactivity.triggers.Length; i++)
+                    {
+                        if (_nd.extensions.MPEG_node_interactivity.triggers[i].type == (int)TriggerType.TRIGGER_COLLISION)
+                        {
+                            _collisionDetector.InitExtension(_nd.extensions.MPEG_node_interactivity.triggers[i]);
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    _collisionDetector.Init();
+                }
+
+                _col = _collisionDetector;
+            }
+
+            _col.AddTarget(obj);
+
+            if (!m_CollisionsDetectors.Contains(_col))
+            {
+                m_CollisionsDetectors.Add(_col);
+            }
+
+            return _col;
+        }
+
+        private void Update()
+        {
+            bool result = true;
+
+            for (int i = 0; i < m_CollisionsDetectors.Count; i++)
+            {
+                if (!m_CollisionsDetectors[i].Collides)
+                {
+                    result = false;
+                }
+            }
+            m_Collides = result;
+        }
+    }
+}

--- a/Runtime/Scripts/CollisionSceneTrigger.cs.meta
+++ b/Runtime/Scripts/CollisionSceneTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 21c39a07bd10cb445adfa022d42a44e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Extensions.cs
+++ b/Runtime/Scripts/Extensions.cs
@@ -13,6 +13,18 @@
 // limitations under the License.
 //
 
+// All modification marked by "//// IDCC" are created by InterDigital and subject to the following header
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
 using UnityEngine;
 
 namespace GLTFast {
@@ -65,7 +77,11 @@ namespace GLTFast {
         AccessorTimed,
         Media,
         TextureVideo,
-        SpatialAudio
+        SpatialAudio,
+        
+        //// IDCC
+        MPEGSceneInteractivity,
+        MPEGNodeInteractivity
     }
 
 /// <summary>
@@ -121,6 +137,9 @@ public static class ExtensionName {
         public const string Media = "MPEG_media";
         public const string TextureVideo = "MPEG_texture_video";
         public const string SpatialAudio = "MPEG_audio_spatial";
+        //// IDCC
+        public const string SceneInteractivity = "MPEG_scene_interactivity";
+        public const string NodeInteractivity = "MPEG_node_interactivity";
 
         /// <summary>
         /// Returns the official name of the glTF extension
@@ -159,6 +178,11 @@ public static class ExtensionName {
                     return TextureVideo;
                 case Extension.SpatialAudio:
                     return SpatialAudio;
+                //// IDCC
+                case Extension.MPEGSceneInteractivity:
+                    return SceneInteractivity;
+                case Extension.MPEGNodeInteractivity:
+                    return NodeInteractivity;
                 default:
                     return null;
             }

--- a/Runtime/Scripts/GameObjectInstantiator.cs
+++ b/Runtime/Scripts/GameObjectInstantiator.cs
@@ -43,6 +43,7 @@ using Mesh = UnityEngine.Mesh;
 namespace GLTFast {
     
     using Logging;
+    using UnityEngine.XR;
 
     /// <summary>
     /// Generates a GameObject hierarchy from a glTF scene 
@@ -469,7 +470,24 @@ namespace GLTFast {
 
             cam.orthographic = false;
 
-            cam.fieldOfView = verticalFieldOfView * Mathf.Rad2Deg;
+            // TODO: Move this code elsewhere
+            // Look if a XR device is in use
+            bool _isXrInUse = false;
+            List<XRDisplaySubsystem> xrDisplaySubsystems = new List<XRDisplaySubsystem>();
+            SubsystemManager.GetInstances(xrDisplaySubsystems);
+            foreach (var xrDisplay in xrDisplaySubsystems)
+            {
+                if (xrDisplay.running) {
+                    _isXrInUse = true;
+                    break;
+                }
+            }
+
+            // Field of view can't be changed while xr is in use
+            if(!_isXrInUse) {
+                cam.fieldOfView = verticalFieldOfView * Mathf.Rad2Deg;
+            }
+
             cam.nearClipPlane = nearClipPlane * localScale;
             cam.farClipPlane = farClipPlane * localScale;
 

--- a/Runtime/Scripts/GameObjectInstantiator.cs
+++ b/Runtime/Scripts/GameObjectInstantiator.cs
@@ -13,6 +13,18 @@
 // limitations under the License.
 //
 
+// All modification marked by "//// IDCC" are created by InterDigital and subject to the following header
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
 using System;
 using System.Collections.Generic;
 using GLTFast.Schema;
@@ -59,6 +71,22 @@ namespace GLTFast {
             /// </summary>
             public Animation legacyAnimation { get; private set; }
 #endif
+
+            //// IDCC
+            public BehaviorController behaviorController
+            {
+                get
+                {
+                    if(m_BehaviorController == null)
+                    {
+                        // Create a behavior controller to handle all behaviors
+                        m_BehaviorController = new GameObject("BehaviorController").AddComponent<BehaviorController>();
+                        m_BehaviorController.Init();
+                    }
+                    return m_BehaviorController;
+                }
+            }
+            private BehaviorController m_BehaviorController;
 
             public List<SpatialAudioSource> audioSources { get; private set; }
             public AudioListener audioListener { get; private set; }
@@ -137,7 +165,12 @@ namespace GLTFast {
         /// Contains information about the latest instance of a glTF scene
         /// </summary>
         public SceneInstance sceneInstance { get; protected set; }
-        
+
+        /// <summary>
+        /// Maintain a count of animations
+        /// </summary>
+        private int m_AnimationCounter;
+
         /// <summary>
         /// Constructs a GameObjectInstantiator
         /// </summary>
@@ -179,6 +212,11 @@ namespace GLTFast {
                 sceneGameObject.layer = settings.layer;
             }
             sceneTransform = sceneGameObject.transform;
+
+            //// IDCC
+            VirtualSceneGraph.AssignSceneTransform(sceneTransform);
+            //// IDCC
+            ///
             Profiler.EndSample();
         }
 
@@ -234,6 +272,9 @@ namespace GLTFast {
                         if (index < 1) {
                             animation.clip = clip;
                         }
+                        //// IDCC
+                        VirtualSceneGraph.AssignAnimationIndexToAnimation(m_AnimationCounter++, clip.name, animation);
+                        //// IDCC
                     }
 
                     sceneInstance.SetLegacyAnimation(animation);
@@ -265,6 +306,10 @@ namespace GLTFast {
             go.transform.SetParent(
                 parentIndex.HasValue ? nodes[parentIndex.Value].transform : sceneTransform,
                 false);
+
+            //// IDCC
+            VirtualSceneGraph.AssignGameObjectToNode((int)nodeIndex, go, (int)nodeIndex);
+            //// IDCC
         }
 
         /// <inheritdoc />
@@ -392,7 +437,8 @@ namespace GLTFast {
                     o.zfar >=0 ? o.zfar : (float?) null,
                     o.xmag,
                     o.ymag,
-                    camera.name
+                    camera.name,
+                    cameraIndex
                 );
                 break;
             case Schema.Camera.Type.Perspective:
@@ -403,7 +449,8 @@ namespace GLTFast {
                     p.znear,
                     p.zfar,
                     p.aspectRatio>0 ? p.aspectRatio : (float?)null,
-                    camera.name
+                    camera.name,
+                    cameraIndex
                 );
                 break;
             }
@@ -415,7 +462,8 @@ namespace GLTFast {
             float nearClipPlane,
             float farClipPlane,
             float? aspectRatio,
-            string cameraName
+            string cameraName,
+            uint cameraIndex
         ) {
             var cam = CreateCamera(nodeIndex,cameraName,out var localScale);
 
@@ -425,6 +473,10 @@ namespace GLTFast {
             cam.nearClipPlane = nearClipPlane * localScale;
             cam.farClipPlane = farClipPlane * localScale;
 
+            //// IDCC
+            VirtualSceneGraph.AssignCameraIndexToCamera((int)cameraIndex, cam);
+            //// IDCC
+            
             // // If the aspect ratio is given and does not match the
             // // screen's aspect ratio, the viewport rect is reduced
             // // to match the glTFs aspect ratio (box fit)
@@ -439,7 +491,8 @@ namespace GLTFast {
             float? farClipPlane,
             float horizontal,
             float vertical,
-            string cameraName
+            string cameraName,
+            uint cameraIndex
         ) {
             var cam = CreateCamera(nodeIndex,cameraName,out var localScale);
             
@@ -564,6 +617,72 @@ namespace GLTFast {
             
             sceneInstance.SetAudioListener(aLstn);
         }
+
+        //// IDCC
+        public void AddMPEGInteractivityBehavior(Schema.Behavior bhv, int index)
+        {
+            GameObject go = new GameObject($"Behavior - {index}");
+
+            // Not useful to have an interface here, but following
+            // the same pattern than actions and triggers
+            IMpegInteractivityBehavior bhvIf = go.AddComponent<GLTFast.Behavior>();
+            bhvIf.InitializeBehavior(bhv);
+
+            sceneInstance.behaviorController.AddBehavior(bhvIf);
+            VirtualSceneGraph.AssignBehaviorIndexToBehavior(bhvIf, index);
+        }
+
+        public void AddMPEGInteractivityTrigger(GLTFast.Schema.Trigger trigger, int index)
+        {
+            GameObject go = new GameObject($"{trigger.type} - {index}");
+            IMpegInteractivityTrigger triggerIf = null;
+
+            switch (trigger.type)
+            {
+                case TriggerType.TRIGGER_COLLISION: triggerIf = go.AddComponent<CollisionSceneTrigger>(); break;
+                case TriggerType.TRIGGER_PROXIMITY: triggerIf = go.AddComponent<ProximitySceneTrigger>(); break;
+                case TriggerType.TRIGGER_USER_INPUT: triggerIf = go.AddComponent<UserInputSceneTrigger>(); break;
+                case TriggerType.TRIGGER_VISIBILITY: triggerIf = go.AddComponent<VisibilitySceneTrigger>(); break;
+            }
+
+            if (triggerIf == null)
+            {
+                throw new NotImplementedException($"Couldn't create trigger, type not recognized: {trigger.type}");
+            }
+
+            triggerIf.Init(trigger);
+
+            VirtualSceneGraph.AssignTriggerToIndex(triggerIf, index);
+        }
+
+        public void AddMPEGInteractivityAction(GLTFast.Schema.Action action, int index)
+        {
+            GameObject go = new GameObject($"{action.type} - {index}");
+            IMpegInteractivityAction actionIf = null;
+
+            switch (action.type)
+            {
+                case ActionType.ACTION_ACTIVATE: actionIf = go.AddComponent<ActionActivate>(); break;
+                case ActionType.ACTION_TRANSFORM: actionIf = go.AddComponent<ActionTransform>(); break;
+                case ActionType.ACTION_BLOCK: actionIf = go.AddComponent<ActionBlock>(); break;
+                case ActionType.ACTION_ANIMATION: actionIf = go.AddComponent<ActionAnimation>(); break;
+                case ActionType.ACTION_MEDIA: actionIf = go.AddComponent<ActionMedia>(); break;
+                case ActionType.ACTION_MANIPULATE: actionIf = go.AddComponent<ActionManipulate>(); break;
+                case ActionType.ACTION_SET_MATERIAL: actionIf = go.AddComponent<ActionSetMaterial>(); break;
+                case ActionType.ACTION_SET_HAPTIC: actionIf = go.AddComponent<ActionSetHaptic>(); break;
+                case ActionType.ACTION_SET_AVATAR: actionIf = go.AddComponent<ActionSetAvatar>(); break;
+            }
+
+            if (actionIf == null)
+            {
+                throw new NotImplementedException($"Couldn't create action, type not recognized: {action.type} : {index}");
+            }
+
+            actionIf.Init(action);
+
+            VirtualSceneGraph.AssignActionToIndex(actionIf, index);
+        }
+
 
         /// <inheritdoc />
         public virtual void EndScene(uint[] rootNodeIndices) {

--- a/Runtime/Scripts/GameObjectInstantiator.cs
+++ b/Runtime/Scripts/GameObjectInstantiator.cs
@@ -560,7 +560,7 @@ namespace GLTFast {
             var cam = camGo.AddComponent<Camera>();
 
             // By default, imported cameras are not enabled by default
-            cam.enabled = false;
+            // cam.enabled = false;
 
             sceneInstance.AddCamera(cam);
 

--- a/Runtime/Scripts/IInstantiator.cs
+++ b/Runtime/Scripts/IInstantiator.cs
@@ -150,6 +150,21 @@ namespace GLTFast {
             uint nodeIndex
         );
 
+        void AddMPEGInteractivityBehavior(
+            GLTFast.Schema.Behavior bhv,
+            int index
+        );
+
+        void AddMPEGInteractivityTrigger(
+            GLTFast.Schema.Trigger trigger,
+            int index
+        );
+
+        void AddMPEGInteractivityAction(
+            GLTFast.Schema.Action action,
+            int index
+        );
+
 
         /// <summary>
         /// Is called at last, after all scene content has been created.

--- a/Runtime/Scripts/IMpegInteractivityAction.cs
+++ b/Runtime/Scripts/IMpegInteractivityAction.cs
@@ -1,0 +1,36 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using Action = GLTFast.Schema.Action;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Any action should implement this interface to be 
+    /// compatible with the Mpeg interactivity extensions
+    /// </summary>
+    public interface IMpegInteractivityAction
+    {
+        public float Delay { get; }
+
+        /// <summary>
+        /// Invoke the implemented action
+        /// </summary>
+        void Invoke();
+
+        /// <summary>
+        /// Initialize action based on MpegSceneInteractivity 
+        /// extension parsed Trigger
+        /// </summary>
+        /// <param name="action"></param>
+        void Init(Action action);
+    }
+}

--- a/Runtime/Scripts/IMpegInteractivityAction.cs.meta
+++ b/Runtime/Scripts/IMpegInteractivityAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2592e203003ad534f8f5ada1243630fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/IMpegInteractivityBehavior.cs
+++ b/Runtime/Scripts/IMpegInteractivityBehavior.cs
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Any behavior should implement this interface to be 
+    /// compatible with the Mpeg interactivity extensions
+    /// </summary>
+    public interface IMpegInteractivityBehavior
+    {
+        /// <summary>
+        /// Initialise MpegInteractivityBehavior based on the MpegSceneInteractivity extension
+        /// And the parsed Behavior
+        /// </summary>
+        /// <param name="ext">Scene level reference</param>
+        /// <param name="bhv">Current behavior reference</param>
+        public void InitializeBehavior(GLTFast.Schema.Behavior bhv);
+
+        /// <summary>
+        /// Prevent the Behavior for running until it is started again.
+        /// If an interrupt action is defined, it is played
+        /// </summary>
+        public void Interrupt();
+
+        /// <summary>
+        /// Return whether or not behavior triggers respond to validation criteria
+        /// </summary>
+        public bool AreTriggersActived();
+
+        /// <summary>
+        /// Activate related actions whenever a trigger is activated
+        /// </summary>
+        public void ActivateActions();
+
+        /// <summary>
+        /// Associate game engine action to interactivity framework action
+        /// </summary>
+        public void AddGameEngineAction(System.Action action);
+    }
+}

--- a/Runtime/Scripts/IMpegInteractivityBehavior.cs.meta
+++ b/Runtime/Scripts/IMpegInteractivityBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a56f1e0e24cf988439697c3dfc68f418
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/IMpegInteractivityTrigger.cs
+++ b/Runtime/Scripts/IMpegInteractivityTrigger.cs
@@ -1,0 +1,34 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Any trigger should implement this interface to be 
+    /// compatible with the Mpeg interactivity extensions
+    /// </summary>
+    public interface IMpegInteractivityTrigger
+    {
+        /// <summary>
+        /// Returns if the trigger meet the behavior conditions
+        /// </summary>
+        bool MeetConditions();
+
+        /// <summary>
+        /// Initialize trigger based on MpegSceneInteractivity 
+        /// extension parsed Trigger
+        /// </summary>
+        /// <param name="trigger"></param>
+        void Init(Trigger trigger);
+    }
+}

--- a/Runtime/Scripts/IMpegInteractivityTrigger.cs.meta
+++ b/Runtime/Scripts/IMpegInteractivityTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 383e784bda7e2f44aace2e944bc026c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/JsonParser.cs
+++ b/Runtime/Scripts/JsonParser.cs
@@ -201,6 +201,13 @@ namespace GLTFast {
                                 e.MPEG_audio_spatial = null;
                             }
                         }
+                        if(e.MPEG_node_interactivity != null)
+                        {
+                            if(e.MPEG_node_interactivity.triggers == null)
+                            {
+                                e.MPEG_node_interactivity = null;
+                            }
+                        }
                         /* Unset `extension` if none of them was valid
                         if (e.EXT_mesh_gpu_instancing == null && 
                             e.KHR_lights_punctual == null ) {

--- a/Runtime/Scripts/PrimitivesHelper.cs
+++ b/Runtime/Scripts/PrimitivesHelper.cs
@@ -1,0 +1,440 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using UnityEngine;
+
+namespace GLTFast
+{
+    public static class PrimitivesHelper
+    {
+        public static Mesh PrimitivesCreateBoxMesh(float width,
+            float height,
+            float length,
+            Vector3 centroid)
+        {
+            float _x = width / 2.0f;
+            float _y = height / 2.0f;
+            float _z = length / 2.0f;
+
+            // Vertices
+            Vector3[] vertices = {
+                new Vector3 (-_x,-_y,-_z),  // bottom left
+                new Vector3 ( _x,-_y,-_z),  // bottom right
+                new Vector3 ( _x, _y,-_z),  // top right
+                new Vector3 (-_x, _y,-_z),  // top left
+                new Vector3 (-_x, _y, _z),  // rear top left
+                new Vector3 ( _x, _y, _z),  // rear top right
+                new Vector3 ( _x,-_y, _z),  // rear bottom right
+                new Vector3 (-_x,-_y, _z),  // rear bottom left
+            };
+
+            OffsetVerticesFromCentroid(vertices, centroid);
+
+            int[] triangles = {
+                0, 2, 1, //face front
+	            0, 3, 2,
+                2, 3, 4, //face top
+	            2, 4, 5,
+                1, 2, 5, //face right
+	            1, 5, 6,
+                0, 7, 4, //face left
+	            0, 4, 3,
+                5, 4, 7, //face back
+	            5, 7, 6,
+                0, 6, 7, //face bottom
+	            0, 1, 6
+            };
+
+            Mesh _msh = new Mesh();
+            _msh.vertices = vertices;
+            _msh.triangles = triangles;
+            _msh.Optimize();
+            _msh.RecalculateNormals();
+            return _msh;
+        }
+
+        public static Mesh PrimitivesCreatePlaneMesh(float width,
+            float length,
+            Vector3 centroid)
+        {
+            float _x = width / 2.0f;
+            float _z = length / 2.0f;
+
+            // Vertices
+            Vector3[] vertices = {
+                new Vector3 (-_x,0,-_z),  // bottom left
+                new Vector3 ( _x,0,-_z),  // bottom right
+                new Vector3 ( _x,0, _z),  // rear bottom right
+                new Vector3 (-_x,0, _z),  // rear bottom left
+            };
+
+            // Centroid here should be the pivot of the cube, so offset the vertices
+            // from there
+            OffsetVerticesFromCentroid(vertices, centroid);
+
+            int[] triangles = {
+                0, 2, 1, //face front
+	            0, 3, 2
+            };
+
+            Mesh _msh = new Mesh();
+            _msh.vertices = vertices;
+            _msh.triangles = triangles;
+            _msh.Optimize();
+            _msh.RecalculateNormals();
+            return _msh;
+        }
+
+        public static Mesh PrimitivesCreateCylinderMesh(float radius,
+            float length,
+            Vector3 centroid)
+        {
+            if (radius <= 0.0f || length == 0.0f)
+            {
+                throw new System.Exception("Failed creating cylinder please enter a valid cylinder radius or length");
+            }
+
+            int stacks = 1;
+            int slices = 32;
+            float sliceStep = (float)Mathf.PI * 2.0f / slices;
+            float currentHeight = -length / 2;
+            int vertexCount = (stacks + 1) * slices + 2;
+            int triangleCount = (stacks + 1) * slices * 2;
+            int indexCount = triangleCount * 3;
+            float currentRadius = radius;
+
+            Vector3[] cylinderVertices = new Vector3[vertexCount];
+
+            // Start at the bottom of the cylinder            
+            int currentVertex = 0;
+            cylinderVertices[currentVertex] = new Vector3(0, currentHeight, 0);
+            currentVertex++;
+
+            for (int i = 0; i <= stacks; i++)
+            {
+                float sliceAngle = 0;
+                for (int j = 0; j < slices; j++)
+                {
+                    float x = currentRadius * (float)Mathf.Cos(sliceAngle);
+                    float y = currentHeight;
+                    float z = currentRadius * (float)Mathf.Sin(sliceAngle);
+
+                    Vector3 position = new Vector3(x, y, z);
+                    cylinderVertices[currentVertex] = position;
+                    currentVertex++;
+
+                    sliceAngle += sliceStep;
+                }
+                currentHeight += length;
+            }
+
+            cylinderVertices[currentVertex] = new Vector3(0, length / 2, 0);
+
+            OffsetVerticesFromCentroid(cylinderVertices, centroid);
+
+            Mesh mesh = new Mesh();
+            mesh.vertices = cylinderVertices;
+            mesh.triangles = CreateIndexBuffer(vertexCount, indexCount, slices);
+            mesh.Optimize();
+            mesh.RecalculateNormals();
+            return mesh;
+        }
+
+        public static Mesh PrimitivesCreateCapsuleMesh(float radius,
+            Vector3 baseCentroid,
+            Vector3 topCentroid)
+        {
+            float height = 2.0f;
+            int segments = 24;
+
+            if (segments % 2 != 0)
+                segments++;
+
+            int points = segments + 1;
+
+            float[] pX = new float[points];
+            float[] pZ = new float[points];
+            float[] pY = new float[points];
+            float[] pR = new float[points];
+
+            float calcH = 0f;
+            float calcV = 0f;
+
+            for (int i = 0; i < points; i++)
+            {
+                pX[i] = Mathf.Sin(calcH * Mathf.Deg2Rad);
+                pZ[i] = Mathf.Cos(calcH * Mathf.Deg2Rad);
+                pY[i] = Mathf.Cos(calcV * Mathf.Deg2Rad);
+                pR[i] = Mathf.Sin(calcV * Mathf.Deg2Rad);
+
+                calcH += 360f / (float)segments;
+                calcV += 180f / (float)segments;
+            }
+
+
+            Vector3[] vertices = new Vector3[points * (points + 1)];
+            int ind = 0;
+
+            float yOff = (height - (radius * 2f)) * 0.5f;
+            if (yOff < 0)
+                yOff = 0;
+
+            // Top Hemisphere
+            int top = Mathf.CeilToInt((float)points * 0.5f);
+
+            for (int y = 0; y < top; y++)
+            {
+                for (int x = 0; x < points; x++)
+                {
+                    vertices[ind] = new Vector3(pX[x] * pR[y], pY[y], pZ[x] * pR[y]) * radius;
+                    vertices[ind].y = yOff + vertices[ind].y;
+                    vertices[ind] += topCentroid;
+
+                    ind++;
+                }
+            }
+
+            // Bottom Hemisphere
+            int btm = Mathf.FloorToInt((float)points * 0.5f);
+
+            for (int y = btm; y < points; y++)
+            {
+                for (int x = 0; x < points; x++)
+                {
+                    vertices[ind] = new Vector3(pX[x] * pR[y], pY[y], pZ[x] * pR[y]) * radius;
+                    vertices[ind].y = -yOff + vertices[ind].y;
+                    vertices[ind] += baseCentroid;
+
+                    ind++;
+                }
+            }
+
+            // TODO: Rotate the hemisphere before the bridge
+
+            // Triangles
+            int[] triangles = new int[(segments * (segments + 1) * 2 * 3)];
+
+            for (int y = 0, t = 0; y < segments + 1; y++)
+            {
+                for (int x = 0; x < segments; x++, t += 6)
+                {
+                    triangles[t + 0] = ((y + 0) * (segments + 1)) + x + 0;
+                    triangles[t + 1] = ((y + 1) * (segments + 1)) + x + 0;
+                    triangles[t + 2] = ((y + 1) * (segments + 1)) + x + 1;
+
+                    triangles[t + 3] = ((y + 0) * (segments + 1)) + x + 1;
+                    triangles[t + 4] = ((y + 0) * (segments + 1)) + x + 0;
+                    triangles[t + 5] = ((y + 1) * (segments + 1)) + x + 1;
+                }
+            }
+            Mesh mesh = new Mesh();
+            mesh.vertices = vertices;
+            mesh.triangles = triangles;
+            //mesh.bounds
+            //mesh.RecalculateBounds();
+            mesh.RecalculateNormals();
+            mesh.Optimize();
+            return mesh;
+        }
+
+        public static Mesh PrimitivesCreateSpheroidMesh(float radius,
+            Vector3 centroid)
+        {
+            int stacks = 16;
+            int slices = 32;
+            float sliceStep = (float)Mathf.PI * 2.0f / slices;
+            float stackStep = (float)Mathf.PI / stacks;
+            int vertexCount = slices * (stacks - 1) + 2;
+            int triangleCount = slices * (stacks - 1) * 2;
+            int indexCount = triangleCount * 3;
+
+            Vector3[] sphereVertices = new Vector3[vertexCount];
+
+            int currentVertex = 0;
+            sphereVertices[currentVertex] = new Vector3(0, -radius, 0);
+            currentVertex++;
+            float stackAngle = (float)Mathf.PI - stackStep;
+            for (int i = 0; i < stacks - 1; i++)
+            {
+                float sliceAngle = 0;
+                for (int j = 0; j < slices; j++)
+                {
+                    //NOTE: y and z were switched from normal spherical coordinates because the sphere is "oriented" along the Y axis as opposed to the Z axis
+                    float x = (float)(radius * Mathf.Sin(stackAngle) * Mathf.Cos(sliceAngle));
+                    float y = (float)(radius * Mathf.Cos(stackAngle));
+                    float z = (float)(radius * Mathf.Sin(stackAngle) * Mathf.Sin(sliceAngle));
+
+                    Vector3 position = new Vector3(x, y, z);
+                    sphereVertices[currentVertex] = position;
+
+                    currentVertex++;
+
+                    sliceAngle += sliceStep;
+                }
+                stackAngle -= stackStep;
+            }
+            sphereVertices[currentVertex] = new Vector3(0, radius, 0);
+
+            OffsetVerticesFromCentroid(sphereVertices, centroid);
+
+            Mesh mesh = new Mesh();
+            mesh.vertices = sphereVertices;
+            mesh.triangles = CreateIndexBuffer(vertexCount, indexCount, slices);
+            mesh.Optimize();
+            mesh.RecalculateNormals();
+            return mesh;
+        }
+
+        private static void OffsetVerticesFromCentroid(Vector3[] vertices, Vector3 _centroid)
+        {
+            for (int i = 0; i < vertices.Length; i++)
+            {
+                vertices[i] += _centroid;
+            }
+        }
+
+        private static int[] CreateIndexBuffer(int vertexCount, int indexCount, int slices)
+        {
+            int[] indices = new int[indexCount];
+            int currentIndex = 0;
+
+            // Bottom circle/cone of shape
+            for (int i = 1; i <= slices; i++)
+            {
+                indices[currentIndex++] = i;
+                indices[currentIndex++] = 0;
+                if (i - 1 == 0)
+                    indices[currentIndex++] = i + slices - 1;
+                else
+                    indices[currentIndex++] = i - 1;
+            }
+
+            // Middle sides of shape
+            for (int i = 1; i < vertexCount - slices - 1; i++)
+            {
+                indices[currentIndex++] = i + slices;
+                indices[currentIndex++] = i;
+                if ((i - 1) % slices == 0)
+                    indices[currentIndex++] = i + slices + slices - 1;
+                else
+                    indices[currentIndex++] = i + slices - 1;
+
+                indices[currentIndex++] = i;
+                if ((i - 1) % slices == 0)
+                    indices[currentIndex++] = i + slices - 1;
+                else
+                    indices[currentIndex++] = i - 1;
+                if ((i - 1) % slices == 0)
+                    indices[currentIndex++] = i + slices + slices - 1;
+                else
+                    indices[currentIndex++] = i + slices - 1;
+            }
+
+            // Top circle/cone of shape
+            for (int i = vertexCount - slices - 1; i < vertexCount - 1; i++)
+            {
+                indices[currentIndex++] = i;
+                if ((i - 1) % slices == 0)
+                    indices[currentIndex++] = i + slices - 1;
+                else
+                    indices[currentIndex++] = i - 1;
+                indices[currentIndex++] = vertexCount - 1;
+            }
+
+            return indices;
+        }
+
+        public static GameObject PrimitivesCreateCuboidGameObject(float width,
+            float height,
+            float length,
+            Vector3 centroid, 
+            bool rendered = true)
+        {
+            Mesh _msh = PrimitivesCreateBoxMesh(width, height, length, centroid);
+            GameObject _box = new GameObject("Cube");
+            MeshFilter _filter = _box.AddComponent<MeshFilter>();
+            _filter.mesh = _msh;
+            if(rendered)
+            {
+                MeshRenderer _rdr = _box.AddComponent<MeshRenderer>();
+                _rdr.material = new Material(Shader.Find("Diffuse"));
+            }
+            return _box;
+        }
+
+        public static GameObject PrimitivesCreatePlaneGameObject(float width,
+            float length,
+            Vector3 centroid,
+            bool rendered = true)
+        {
+            Mesh _msh = PrimitivesCreatePlaneMesh(width, length, centroid);
+            GameObject _plane = new GameObject("Plane");
+            MeshFilter _filter = _plane.AddComponent<MeshFilter>();
+            _filter.mesh = _msh;
+            if (rendered)
+            {
+                MeshRenderer _rdr = _plane.AddComponent<MeshRenderer>();
+                _rdr.material = new Material(Shader.Find("Diffuse"));
+            }
+            return _plane;
+        }
+
+        public static GameObject PrimitivesCreateCylinderGameObject(float radius,
+            float height,
+            Vector3 centroid,
+            bool rendered = true)
+        {
+            Mesh _msh = PrimitivesCreateCylinderMesh(radius, height, centroid);
+            GameObject _cylinder = new GameObject("Cylinder");
+            MeshFilter _filter = _cylinder.AddComponent<MeshFilter>();
+            _filter.mesh = _msh;
+            if (rendered)
+            {
+                MeshRenderer _rdr = _cylinder.AddComponent<MeshRenderer>();
+                _rdr.material = new Material(Shader.Find("Diffuse"));
+            }
+            return _cylinder;
+        }
+
+        public static GameObject PrimitivesCreateSpheroidGameObject(float radius,
+            Vector3 centroid,
+            bool rendered = true)
+        {
+            Mesh _msh = PrimitivesCreateSpheroidMesh(radius, centroid);
+            GameObject _sphere = new GameObject("Sphere");
+            MeshFilter _filter = _sphere.AddComponent<MeshFilter>();
+            _filter.mesh = _msh;
+            if (rendered)
+            {
+                MeshRenderer _rdr = _sphere.AddComponent<MeshRenderer>();
+                _rdr.material = new Material(Shader.Find("Diffuse"));
+            }
+            return _sphere;
+        }
+
+        public static GameObject PrimitivesCreateCapsuleGameObject(float radius, 
+            Vector3 baseCentroid,
+            Vector3 topCentroid,
+            bool rendered = true)
+        {
+            Mesh _msh = PrimitivesCreateCapsuleMesh(radius, baseCentroid, topCentroid);
+            GameObject _capsule = new GameObject("Capsule");
+            MeshFilter _filter = _capsule.AddComponent<MeshFilter>();
+            _filter.mesh = _msh;
+            if (rendered)
+            {
+                MeshRenderer _rdr = _capsule.AddComponent<MeshRenderer>();
+                _rdr.material = new Material(Shader.Find("Diffuse"));
+            }
+            return _capsule;
+        }
+    }
+}

--- a/Runtime/Scripts/PrimitivesHelper.cs.meta
+++ b/Runtime/Scripts/PrimitivesHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0f6c2160eae1394891b3ead8cd505b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/ProximityNodeTrigger.cs
+++ b/Runtime/Scripts/ProximityNodeTrigger.cs
@@ -1,0 +1,71 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+using System;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Represent the proximity trigger at the node level
+    /// </summary>
+    public class ProximityNodeTrigger : MonoBehaviour
+    {
+        private float m_DistanceLowerLimit;
+        private float m_DistanceUpperLimit;
+
+        private float m_UpperDistanceWeight;
+        private float m_LowerDistanceWeight;
+        private bool m_AllowOcclusion;
+        private GameObject[] m_Primitives;
+
+        private float m_LowerDistance;
+        private float m_UpperDistance;
+
+        public void InitSceneAndNodeLevelExtension(MpegNodeInteractivity.Trigger trigger, Trigger _proximityTrigger)
+        {
+            m_DistanceLowerLimit = _proximityTrigger.distanceLowerLimit;
+            m_DistanceUpperLimit = _proximityTrigger.distanceUpperLimit;
+
+            m_AllowOcclusion = trigger.allowOcclusion;
+            m_UpperDistanceWeight = trigger.upperDistanceWeight;
+            m_LowerDistanceWeight = trigger.lowerDistanceWeight;
+            m_Primitives = new GameObject[trigger.primitives.Length];
+
+            // Lower and upper distance are multiplied by the weight
+            m_UpperDistance *= m_UpperDistanceWeight;
+            m_LowerDistance *= m_LowerDistanceWeight;
+        }
+
+        public void InitSceneLevelExtension(Trigger _proximityTrigger)
+        {
+            m_DistanceLowerLimit = _proximityTrigger.distanceLowerLimit;
+            m_DistanceUpperLimit = _proximityTrigger.distanceUpperLimit;
+
+            m_LowerDistance = m_DistanceLowerLimit;
+            m_UpperDistance = m_DistanceUpperLimit;
+        }
+
+        internal bool IsClose(GameObject _reference)
+        {
+            float _distance = Vector3.Distance(_reference.transform.position,
+                transform.position);
+
+            if(_distance < m_LowerDistance || _distance > m_UpperDistance)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Runtime/Scripts/ProximityNodeTrigger.cs.meta
+++ b/Runtime/Scripts/ProximityNodeTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 910e940beb5a2324881ec18076717d6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/ProximitySceneTrigger.cs
+++ b/Runtime/Scripts/ProximitySceneTrigger.cs
@@ -1,0 +1,207 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GLTFast
+{    
+    /// <summary>
+    /// Represent the proximity trigger at the scene level
+    /// Triggers when the ReferenceNode is above the distance lower limit and 
+    /// below the distance upper limit from the other nodes
+    /// </summary>
+    public class ProximitySceneTrigger : MonoBehaviour, IMpegInteractivityTrigger
+    {
+        private GameObject m_ReferenceObject;
+        private bool m_HasReferenceNode;
+        private float m_DistanceLowerLimit;
+        private float m_DistanceUpperLimit;
+        private List<ProximityNodeTrigger> m_Targets;
+
+        public void Init(Trigger trigger)
+        {
+            m_Targets = new List<ProximityNodeTrigger>();
+            if(trigger.referenceNode.HasValue)
+            {
+                m_HasReferenceNode = true;
+                m_ReferenceObject = VirtualSceneGraph.GetGameObjectFromIndex(trigger.referenceNode.Value);
+            }
+            else
+            {
+                if(UnityEngine.Camera.allCamerasCount == 0)
+                {
+                    throw new Exception("No reference node attached to the Trigger proximity. Please provide at least one reference node");
+                }
+            }
+
+            m_DistanceLowerLimit = trigger.distanceLowerLimit;
+            m_DistanceUpperLimit = trigger.distanceUpperLimit;
+
+            GetFirstActivatedCamera();
+
+
+            if (trigger.primitives == null)
+            {
+                // Create the nodes as usual
+                for(int i = 0; i < trigger.nodes.Length; i++)
+                {
+                    GameObject _target = VirtualSceneGraph.GetGameObjectFromIndex(trigger.nodes[i]);
+
+                    // Initialize proximity detector on all nodes and parse node
+                    // level extensions if any
+                    ProximityNodeTrigger _proximity = InitProximityDetector(ref _target, trigger);
+                    m_Targets.Add(_proximity);
+                }
+            }
+            else
+            {
+                // We assume that the primitives array is of the same length as node array
+                // Add primitives as targets
+                for (int i = 0; i < trigger.nodes.Length; i++)
+                {
+                    Vector3 _nodePos = VirtualSceneGraph.GetGameObjectFromIndex(trigger.nodes[i]).transform.position;
+
+                    GameObject _primitive = null;
+                    switch (trigger.primitives[i].type)
+                    {
+                        case Schema.PrimitiveType.BV_CUBOID:
+                            _primitive = PrimitivesHelper.PrimitivesCreateCuboidGameObject(trigger.primitives[i].width,
+                                trigger.primitives[i].height,
+                                trigger.primitives[i].length,
+                                trigger.primitives[i].centroid);
+                            break;
+                        case Schema.PrimitiveType.BV_PLANE_REGION:
+                            _primitive = PrimitivesHelper.PrimitivesCreatePlaneGameObject(trigger.primitives[i].width,
+                                trigger.primitives[i].height,
+                                trigger.primitives[i].centroid);
+                            break;
+                        case Schema.PrimitiveType.BV_CYLINDER_REGION:
+                            _primitive = PrimitivesHelper.PrimitivesCreateCylinderGameObject(trigger.primitives[i].radius,
+                                trigger.primitives[i].length,
+                                trigger.primitives[i].centroid);
+                            break;
+                        case Schema.PrimitiveType.BV_CAPSULE_REGION:
+                            _primitive = PrimitivesHelper.PrimitivesCreateCapsuleGameObject(trigger.primitives[i].radius,
+                                trigger.primitives[i].baseCentroid,
+                                trigger.primitives[i].topCentroid);
+                            break;
+                        case Schema.PrimitiveType.BV_SPHEROID:
+                            _primitive = PrimitivesHelper.PrimitivesCreateSpheroidGameObject(trigger.primitives[i].radius,
+                                trigger.primitives[i].centroid);
+                            break;
+                    }
+
+                    if (_primitive == null)
+                    {
+                        throw new Exception($"Failed to create Primitive " +
+                            $"- type not found: {trigger.primitives[i].type}");
+                    }
+
+                    // At the scene level, the primitive applies a transformation
+                    // matrix relative to the world. The default trs of the primitive
+                    // is then always identity
+
+                    // Move the primitive according to the transformation matrix
+                    Matrix4x4 m = trigger.primitives[i].transformationMatrix;
+                    Vector3 _pos = m.GetPosition();
+                    Quaternion _rot = m.rotation;
+                    Vector3 _scale = Vector3.one;
+
+                    _primitive.transform.position = _nodePos;
+                    _primitive.transform.localPosition = _pos;
+                    _primitive.transform.rotation = _rot;
+                    _primitive.transform.localScale = _scale;
+
+                    ProximityNodeTrigger _primitiveProximityDetector =
+                        _primitive.AddComponent<ProximityNodeTrigger>();
+
+                    _primitiveProximityDetector.InitSceneLevelExtension(trigger);
+
+                    m_Targets.Add(_primitiveProximityDetector);
+                }
+            }
+        }
+
+        private ProximityNodeTrigger InitProximityDetector(ref GameObject _obj, Trigger _proximityTrigger)
+        {
+            ProximityNodeTrigger _proximity = _obj.AddComponent<ProximityNodeTrigger>();
+            Node _nd = VirtualSceneGraph.GetNodeFromGameObject(_obj);
+
+            // Find if there is any proximity trigger
+            // node extenxtion level to be found
+            if (_nd.extensions?.MPEG_node_interactivity != null)
+            {
+                for(int i = 0; i < _nd.extensions.MPEG_node_interactivity.triggers.Length; i++)
+                {
+                    if (_nd.extensions.MPEG_node_interactivity.triggers[i].type == TriggerType.TRIGGER_PROXIMITY)
+                    {
+                        _proximity.InitSceneAndNodeLevelExtension(
+                            _nd.extensions.MPEG_node_interactivity.triggers[i],
+                            _proximityTrigger);
+                    }
+                }
+            }
+            else
+            {
+                _proximity.InitSceneLevelExtension(_proximityTrigger);
+            }
+            return _proximity;
+        }
+
+        private void GetFirstActivatedCamera()
+        {
+            UnityEngine.Camera[] _cameras = UnityEngine.Camera.allCameras;
+
+            // By default, the reference node is the active camera
+            for (int i = 0; i < _cameras.Length; i++)
+            {
+                // Get the first activated camera by default
+                UnityEngine.Camera _cam = _cameras[i];
+                m_ReferenceObject = _cam.gameObject;
+            }
+        }
+
+        private void Update()
+        {
+            // The proximity trigger should have a reference node and if it doesn't, it
+            // should use the active camera
+            if(!m_HasReferenceNode)
+            {
+                GetFirstActivatedCamera();
+            }
+        }
+
+        public bool MeetConditions()
+        {
+            bool result = true;
+            for (int i = 0; i < m_Targets.Count; i++)
+            {
+                // TODO: Should take in account the node level extension for each object
+                bool _isClose = m_Targets[i].IsClose(m_ReferenceObject);
+                if(!_isClose)
+                {
+                    return false;
+                }
+                //float distance = Vector3.Distance(m_ReferenceObject.transform.position,
+                //    m_Targets[i].transform.position);
+
+                //if (distance < m_DistanceLowerLimit || distance > m_DistanceUpperLimit)
+                //{
+                //    return false;
+                //}
+            }
+            return result;
+        }
+    }
+}

--- a/Runtime/Scripts/ProximitySceneTrigger.cs.meta
+++ b/Runtime/Scripts/ProximitySceneTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4f112e85f82a2b4da89a77f8afc5cca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Schema/MpegBufferCircular.cs
+++ b/Runtime/Scripts/Schema/MpegBufferCircular.cs
@@ -17,6 +17,7 @@ namespace GLTFast.Schema {
     {
         public int media = -1;
         public int count = 2;
+        public int source;
         public int[] tracks;
 
         internal void GltfSerialize(JsonWriter writer) {

--- a/Runtime/Scripts/Schema/MpegNodeInteractivity.cs
+++ b/Runtime/Scripts/Schema/MpegNodeInteractivity.cs
@@ -1,0 +1,203 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using UnityEngine;
+
+namespace GLTFast.Schema
+{    
+    /// <summary>
+    /// In complement to the interactivity objects defined in 
+    /// the glTF scene-level extension, some additional data could 
+    /// be provided at the level of the affected glTF nodes to 
+    /// specialize the trigger activation
+    /// </summary>    
+    public class MpegNodeInteractivity : MonoBehaviour
+    {
+        [System.Serializable]
+        public class Trigger
+        {
+            /// <summary>
+            /// Defines the type of the trigger
+            /// </summary>
+            public TriggerType type;
+
+            /// <summary>
+            /// the index of the mesh element that provides the
+            /// collider geometry for the current node.
+            /// The collider mesh may reference a material.
+            /// </summary>
+            public int collider;
+
+            /// <summary>
+            /// If True, the collider is defined as a static collider.
+            /// </summary>
+            public bool isStatic;
+
+            /// <summary>
+            /// Indicates if the object shall be considered
+            /// by the physics simulation
+            /// </summary>
+            public bool usePhysics;
+
+            /// <summary>
+            /// Indicates if the gravity affects the object
+            /// </summary>
+            public bool useGravity;
+
+            /// <summary>
+            /// Mass of the object in kilogram
+            /// </summary>
+            public float mass;
+
+            /// <summary>
+            /// Provides the ratio of the final to initial 
+            /// relative velocity between two objects after they collide.
+            /// </summary>
+            public float restitution;
+
+            /// <summary>
+            /// Unitless friction coefficient as defined in the Coulomb
+            /// friction model. Friction is the quantity which prevents 
+            /// surfaces from sliding off each other. StaticFriction is
+            /// used when the object is lying still. 
+            /// It will prevent the object from starting to move
+            /// </summary>
+            public float staticFriction;
+
+            /// <summary>
+            /// Unitless friction coefficient as defined in the Coulomb
+            /// friction model. When a large enough force is applied to the
+            /// object, the dynamicFriction is used, and will attempt to slow
+            /// down the object while in contact with another.
+            /// </summary>
+            public float dynamicFriction;
+
+            /// <summary>
+            /// List of primitives used to activate the proximity or collision trigger
+            /// </summary>
+            public GLTFast.Schema.Trigger.Primitive[] primitives;
+
+            /// <summary>
+            /// Indicates if occlusion by other nodes should be considered
+            /// </summary>
+            public bool allowOcclusion;
+
+            /// <summary>
+            /// The weight applied
+            /// to the distanceUpperLimit parameter defined at scene level
+            /// </summary>
+            public float upperDistanceWeight;
+
+            /// <summary>
+            /// The weight applied
+            /// to the distanceLowerLimit parameter defined at scene level
+            /// </summary>
+            public float lowerDistanceWeight;
+
+            /// <summary>
+            /// Provides additional information related to the user 
+            /// inputs (eg “max speed = 0.5”)
+            /// </summary>
+            public string[] userInputParameters;
+
+            /// <summary>
+            /// The visibility computation shall take into account both 
+            /// the occultation by other node(s) and the camera frustrum.
+            /// If the allowsPartialOcclusion Boolean is TRUE, then a partial
+            /// visibility of this node activates the trigger.
+            /// If the allowsPartialOcclusion Boolean is FALSE, then this node
+            /// shall be fully in the camera frustrum and not be occluded by
+            /// any other node(s) except the nodes listed in the nodes array
+            /// to activate the trigger.
+            /// </summary>
+            public bool allowsPartialOcclusion;
+
+            /// <summary>
+            /// Set of nodes that shall not be considered for the visibility
+            /// computation, when the allowsPartialOcclusion is FALSE.
+            /// </summary>
+            public int[] nodes;
+
+            /// <summary>
+            /// Index of the mesh in the scene meshes array that will
+            /// be used to compute visibility.
+            /// </summary>
+            public int mesh;
+
+            internal void GltfSerialize(JsonWriter _writer)
+            {
+                if (type == TriggerType.TRIGGER_COLLISION)
+                {
+                    _writer.AddProperty("collider", collider);
+                    _writer.AddProperty("static", isStatic);
+
+                    if (usePhysics)
+                    {
+                        _writer.AddProperty("useGravity", useGravity);
+                        _writer.AddProperty("mass", mass);
+                        _writer.AddProperty("restitution", restitution);
+                        _writer.AddProperty("staticFriction", staticFriction);
+                        _writer.AddProperty("dynamicFriction", dynamicFriction);
+                    }
+                }
+                else if (type == TriggerType.TRIGGER_PROXIMITY)
+                {
+                    _writer.AddProperty("allowOcclusion", allowOcclusion);
+                    _writer.AddProperty("upperDistanceWeight", upperDistanceWeight);
+                    _writer.AddProperty("lowerDistanceWeight", lowerDistanceWeight);
+                    _writer.AddArray("primitives");
+                    for(int i = 0; i < primitives.Length; i++)
+                    {
+                        _writer.AddProperty($"{primitives[i]}");
+                    }
+                    _writer.CloseArray();
+                }
+                else if(type == TriggerType.TRIGGER_USER_INPUT)
+                {
+                    _writer.AddArray("userInputParameters");
+                    for(int i = 0; i < userInputParameters.Length; i++)
+                    {
+                        _writer.AddProperty($"{userInputParameters[i]}");
+                    }
+                    _writer.CloseArray();
+                }
+                else if(type == TriggerType.TRIGGER_VISIBILITY)
+                {
+                    _writer.AddProperty("allowsPartialOcclusion", allowsPartialOcclusion);
+                    _writer.AddArray("nodes");
+                    for(int i = 0; i < nodes.Length; i++)
+                    {
+                        _writer.AddProperty($"{nodes[i]}");
+                    }
+                    _writer.CloseArray();
+                }
+                _writer.AddProperty($"{mesh}");
+            }
+        }
+
+        /// <summary>
+        /// Array of node triggers. Only distinct types are allowed.
+        /// The minimum size of this array is 1, and the maximum size is the size of
+        /// trigger types as defined in the specification.
+        /// </summary>
+        public Trigger[] triggers;
+
+        internal void GltfSerialize(JsonWriter _writer)
+        {
+            _writer.AddObject();
+            for (int i = 0; i < triggers.Length; i++)
+            {
+                triggers[i].GltfSerialize(_writer);
+            }
+            _writer.Close();
+        }
+    }
+}

--- a/Runtime/Scripts/Schema/MpegNodeInteractivity.cs
+++ b/Runtime/Scripts/Schema/MpegNodeInteractivity.cs
@@ -19,7 +19,8 @@ namespace GLTFast.Schema
     /// be provided at the level of the affected glTF nodes to 
     /// specialize the trigger activation
     /// </summary>    
-    public class MpegNodeInteractivity : MonoBehaviour
+    [System.Serializable]
+    public class MpegNodeInteractivity
     {
         [System.Serializable]
         public class Trigger
@@ -104,7 +105,7 @@ namespace GLTFast.Schema
 
             /// <summary>
             /// Provides additional information related to the user 
-            /// inputs (eg “max speed = 0.5”)
+            /// inputs (eg 'max speed = 0.5')
             /// </summary>
             public string[] userInputParameters;
 

--- a/Runtime/Scripts/Schema/MpegNodeInteractivity.cs.meta
+++ b/Runtime/Scripts/Schema/MpegNodeInteractivity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b57550a45c276e4eafa8e17ff72c489
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Schema/MpegSceneInteractivity.cs
+++ b/Runtime/Scripts/Schema/MpegSceneInteractivity.cs
@@ -533,7 +533,7 @@ namespace GLTFast.Schema
         /// <summary>
         /// Transform matrix to apply to the nodes
         /// </summary>
-        public Matrix4x4 transform;
+        public float[] transform;
 
         /// <summary>
         /// Index of the animation in the animations array to be considered

--- a/Runtime/Scripts/Schema/MpegSceneInteractivity.cs
+++ b/Runtime/Scripts/Schema/MpegSceneInteractivity.cs
@@ -1,0 +1,677 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System;
+using UnityEngine;
+
+namespace GLTFast.Schema
+{
+    // List of haptic action nodes
+    [Serializable]
+    public class HapticActionNode
+    {
+        /// <summary>
+        /// Id of the node in the glTF nodes array
+        /// </summary>
+        public int node;
+
+        /// <summary>
+        /// Index to a haptic object in the hapticObjects array of the 
+        /// MPEG_haptic extension
+        /// </summary>
+        public int hapticObject;
+
+        /// <summary>
+        /// Body part mask specifying where on the body the signal can be rendered.
+        /// </summary>
+        public int actionLocation;
+
+        /// <summary>
+        /// Specifies whether the action should trigger a washout (reset to the origin) 
+        /// of the associated devices
+        /// </summary>
+        public bool washout;
+
+        /// <summary>
+        /// Used with a Collision trigger. If True, the rendering engine shall use collision
+        /// information to estimate the desired location of the haptic feedback on the body.
+        /// If false, the signal shall be rendered based on the information specified in the Haptic file.
+        /// </summary>
+        public bool useCollider;
+
+        /// <summary>
+        /// List of haptic material modalities that shall be rendered.
+        /// </summary>
+        public HapticMaterialModality[] materialHapticModality;
+
+        /// <summary>
+        /// List of Haptic Action Media.
+        /// </summary>
+        public HapticActionMedia[] hapticActionMedias;
+    }
+
+    [Serializable]
+    public class HapticActionMedia
+    {
+        /// <summary>
+        /// Index in the accessors array of the associated haptic data
+        /// </summary>
+        public int mediaIndex;
+
+        /// <summary>
+        /// Indices of the perceptions of the media that shall be rendered.
+        /// If the list if empty all perceptions shall be rendered
+        /// </summary>
+        public int[] perceptionIndices;
+
+        /// <summary>
+        /// List of haptic modalities that can be rendered
+        /// </summary>
+        public HapticModality hapticModality;
+
+        /// <summary>
+        /// One element of that defines the control of the haptic rendering.
+        /// </summary>
+        public HapticControl hapticControl;
+
+        /// <summary>
+        /// Specifies if the haptic rendering of the data should be 
+        /// continuously looping.
+        /// </summary>
+        public bool loop;
+    }
+
+    /// <summary>
+    /// Determine the activation status of somes nodes
+    /// </summary>
+    public enum ActivationStatus
+    {
+        /// <summary>
+        /// The node shall be processed by the application
+        /// </summary>
+        ENABLED = 0,
+
+        /// <summary>
+        /// The node shall be skipped by the application
+        /// </summary>
+        DISABLED = 1
+    }
+
+    /// <summary>
+    /// Defines the control of the haptic rendering
+    /// </summary>
+    public enum HapticControl
+    {
+        /// <summary>
+        /// Start the rendering of the haptic data from time 0
+        /// or from any other time provided by a control
+        /// </summary>
+        HAPTIC_PLAY = 0,
+
+        /// <summary>
+        /// Pause the rendering of the haptic data
+        /// </summary>
+        HAPTIC_PAUSE = 1,
+
+        /// <summary>
+        /// Resume the rendering of the haptic data from the last pause position
+        /// </summary>
+        HAPTIC_RESUME = 2,
+
+        /// <summary>
+        /// Stop the rendering of the haptic data
+        /// </summary>
+        HAPTIC_STOP = 3
+    }
+
+    /// <summary>
+    /// Haptic material modality that can be rendered
+    /// </summary>
+    public enum HapticMaterialModality
+    {
+        STIFFNESS = 0,
+        FRICTION = 1,
+        VIBROTACTILE_TEXTURE = 2,
+        TEMPERATURE = 3,
+        VIBRATION = 4,
+        CUSTOM = 5
+    }
+
+    /// <summary>
+    /// Haptic modality that can be rendered
+    /// </summary>
+    public enum HapticModality
+    {
+        PRESSURE = 0,
+        ACCELERATION = 1,
+        VELOCITY = 2,
+        POSITION = 3,
+        TEMPERATURE = 4,
+        VIBROTACTILE = 5,
+        WATER = 6,
+        WIND = 7,
+        FORCE = 8,
+        ELECTROTACTILE = 9,
+        VIBROTACTILE_TEXTURE = 10,
+        STIFFNESS = 11,
+        FRICTION = 12,
+        OTHER = 13
+    }
+
+    /// <summary>
+    /// Defines the trigger type
+    /// </summary>
+    public enum TriggerType
+    {
+        /// <summary>
+        /// Collision trigger
+        /// </summary>
+        TRIGGER_COLLISION = 0,
+        /// <summary>
+        /// Proximity trigger
+        /// </summary>
+        TRIGGER_PROXIMITY = 1,
+        /// <summary>
+        /// User input trigger
+        /// </summary>
+        TRIGGER_USER_INPUT = 2,
+        /// <summary>
+        /// Visibility trigger
+        /// </summary>
+        TRIGGER_VISIBILITY = 3
+    }
+
+    /// <summary>
+    /// One element that defines the type of the action
+    /// </summary>
+    public enum ActionType
+    {
+        /// <summary>
+        /// Set activation status of a node
+        /// </summary>
+        ACTION_ACTIVATE = 0,
+        /// <summary>
+        /// Set transform to a node
+        /// </summary>
+        ACTION_TRANSFORM = 1,
+        /// <summary>
+        /// Block the transform of a node
+        /// </summary>
+        ACTION_BLOCK = 2,
+        /// <summary>
+        /// Select and control an animation
+        /// </summary>
+        ACTION_ANIMATION = 3,
+        /// <summary>
+        /// Select and control a media
+        /// </summary>
+        ACTION_MEDIA = 4,
+        /// <summary>
+        /// Select a manipulate action
+        /// </summary>
+        ACTION_MANIPULATE = 5,
+        /// <summary>
+        /// Set new material to nodes
+        /// </summary>
+        ACTION_SET_MATERIAL = 6,
+        /// <summary>
+        /// Set haptic feedbacks on a set of nodes
+        /// </summary>
+        ACTION_SET_HAPTIC = 7,
+        /// <summary>
+        /// Set avatar related actions
+        /// </summary>
+        ACTION_SET_AVATAR = 8
+    }
+
+    public enum TriggerActivationControl
+    {
+        /// <summary>
+        /// Activate when the conditions are first met
+        /// </summary>
+        TRIGGER_ACTIVATE_FIRST_ENTER = 0,
+        /// <summary>
+        /// Activate each time the conditions are first met
+        /// </summary>
+        TRIGGER_ACTIVATE_EACH_ENTER = 1,
+        /// <summary>
+        /// Activate as long as the conditions are met
+        /// </summary>
+        TRIGGER_ACTIVE_ON = 2,
+        /// <summary>
+        /// When the conditions are first no longer met
+        /// </summary>
+        TRIGGER_ACTIVATE_FIRST_EXIT = 3,
+        /// <summary>
+        /// Activate each time when the conditions are no longer met
+        /// </summary>
+        TRIGGER_ACTIVATE_EACH_EXIT = 4,
+        /// <summary>
+        /// Activate as long as the conditions are not met
+        /// </summary>
+        TRIGGER_ACTIVATE_OFF = 5
+    }
+
+    /// <summary>
+    /// Describe the animation behavior
+    /// </summary>
+    public enum AnimationControl
+    {
+        /// <summary>
+        /// Play the animation
+        /// </summary>
+        ANIMATION_PLAY = 0,
+        /// <summary>
+        /// Pause the animation
+        /// </summary>
+        ANIMATION_PAUSE = 1,
+        /// <summary>
+        /// Resume the animation
+        /// </summary>
+        ANIMATION_RESUME = 2,
+        /// <summary>
+        /// Stop the animation
+        /// </summary>
+        ANIMATION_STOP = 3
+    }
+
+    /// <summary>
+    /// Defines the control of the media
+    /// </summary>
+    public enum MediaControl
+    {
+        /// <summary>
+        /// Play the media from time 0 or from any other time provided by a control.
+        /// </summary>
+        MEDIA_PLAY = 0,
+        /// <summary>
+        /// Pause the media
+        /// </summary>
+        MEDIA_PAUSE = 1,
+        /// <summary>
+        /// Resume the media from the last pause position
+        /// </summary>
+        MEDIA_RESUME = 2,
+        /// <summary>
+        /// Stop the media
+        /// </summary>
+        MEDIA_STOP = 3
+    }
+
+    /// <summary>
+    /// Primitives used to activate the proximity or collision trigger
+    /// </summary>
+    public enum PrimitiveType
+    {
+        BV_CUBOID = 0,
+        BV_PLANE_REGION = 1,
+        BV_CYLINDER_REGION = 2,
+        BV_CAPSULE_REGION = 3,
+        BV_SPHEROID = 4
+    }
+
+    [Serializable]
+    public class MpegSceneInteractivity
+    {
+        public Trigger[] triggers;
+        public Action[] actions;
+        public GLTFast.Schema.Behavior[] behaviors;
+
+        internal void GltfSerialize(JsonWriter writer)
+        {
+            writer.AddObject();
+
+            writer.AddArray("triggers");
+            foreach (Trigger tr in triggers)
+            {
+                tr.GltfSerialize(writer);
+            }
+            writer.CloseArray();
+
+            writer.AddArray("actions");
+            foreach (Action ac in actions)
+            {
+                ac.GltfSerialize(writer);
+            }
+            writer.CloseArray();
+
+            writer.AddArray("behaviors");
+            foreach (Behavior bhv in behaviors)
+            {
+                bhv.GltfSerialize(writer);
+            }
+            writer.CloseArray();
+            writer.Close();
+        }
+    }
+
+    [Serializable]
+    public class Trigger
+    {
+        [Serializable]
+        public class Primitive
+        {
+            // Main properties
+            /// <summary>
+            /// Describes the type of primitive used to activate the proximity trigger.
+            /// The available options are. BV_CUBOID, BV_PLANE_REGION, BV_CYLINDER_REGION,
+            /// BV_CAPSULE_REGION, and the default BV_SPHEROID.
+            /// </summary>
+            public PrimitiveType type;
+
+            /// <summary>
+            /// Defines the region of intersection within the primitive.
+            /// If zero, then all area of the primitive activates the trigger. 
+            /// Otherwise, the region of intersection decreases following the normal 
+            /// direction of all sides of the primitive from its centroid.
+            /// For the capsule primitive, it should be applied over the radius,
+            /// top, and base attributes.
+            /// </summary>
+            public int boundary;
+
+            /// <summary>
+            /// Floating-point 4x4 matrix that defines the initial orientation,
+            /// translation, and scale of a primitive. Formatted in column-major order.
+            /// The primitive shall follow x+ for width, y+ for height, z+ for length.
+            /// The matrix transformation allows to transform any primitive after initialization.
+            /// </summary>
+            public Matrix4x4 transformationMatrix;
+
+            /// <summary>
+            /// Width of the box
+            /// </summary>
+            public float width;
+
+            /// <summary>
+            /// Height of the box
+            /// </summary>
+            public float height;
+
+            /// <summary>
+            /// Length of the box
+            /// </summary>
+            public float length;
+
+            /// <summary>
+            /// Centroid 3D coordinates(x,y,z) of the box
+            /// </summary>
+            public Vector3 centroid;
+
+            /// <summary>
+            /// Radius of the cylinder, or radius of the sphere
+            /// </summary>
+            public float radius;
+
+            /// <summary>
+            /// Centroid 3D coordinates(x,y,z) of the base semi-sphere of the capsule
+            /// </summary>
+            public Vector3 baseCentroid;
+
+            /// <summary>
+            /// Centroid 3D Coordinates(x,y,z) of the top semi-sphere of the capsule
+            /// </summary>
+            public Vector3 topCentroid;
+        }
+
+        /// <summary>
+        /// Defines the trigger type
+        /// </summary>
+        public TriggerType type;
+
+        /// <summary>
+        /// Nodes considered for trigger calculation
+        /// </summary>
+        public int[] nodes;
+
+        /// <summary>
+        /// List of primitives used to activate the proximity or collision trigger
+        /// </summary>
+        public Primitive[] primitives;
+
+        /// <summary>
+        /// Index of the node consider for the proximity evaluation
+        /// </summary>
+        public int? referenceNode;
+
+        /// <summary>
+        /// Threshold min in meters for the node proximity calculation
+        /// </summary>
+        public float distanceLowerLimit;
+
+        /// <summary>
+        /// Threshold max in meters for the node proximity calculation
+        /// </summary>
+        public float distanceUpperLimit;
+
+        /// <summary>
+        /// Describes the user body part and gesture related to the input
+        /// </summary>
+        public string userInputDescription;
+
+        /// <summary>
+        /// Index of the node containing a camera for which the visibilities
+        /// are determined
+        /// </summary>
+        public int cameraNode;
+
+        internal void GltfSerialize(JsonWriter writer)
+        {
+            writer.AddObject();
+            writer.AddProperty("type", type);
+            writer.AddProperty("userInputDescription", userInputDescription);
+            writer.AddArray("nodes");
+            for (int i = 0; i < nodes.Length; ++i)
+            {
+                writer.AddProperty($"{nodes[i]}");
+            }
+            writer.CloseArray();
+            writer.Close();
+        }
+    }
+
+    [Serializable]
+    public class Action
+    {
+        /// <summary>
+        /// Defines the action manipulate type
+        /// </summary>
+        public enum ManipulateActionType
+        {
+            /// <summary>
+            /// The nodes follow the user pointing device and its rotation
+            /// </summary>
+            ACTION_MANIPULATE_FREE = 0,
+            /// <summary>
+            /// The nodes move linearly along the provided axis by following 
+            /// the user pointing device
+            /// </summary>
+            ACTION_MANIPULATE_SLIDE = 1,
+            /// <summary>
+            /// The nodes translate by following the user pointing device
+            /// </summary>
+            ACTION_MANIPULATE_TRANSLATE = 2,
+            /// <summary>
+            /// The nodes rotate around the provided axis by following the 
+            /// user pointing device
+            /// </summary>
+            ACTION_MANIPULATE_ROTATE = 3,
+            /// <summary>
+            /// Performs a central scaling of the nodes by following the user 
+            /// pointing device 
+            /// </summary>
+            ACTION_MANIPULATE_SCALE = 4
+        }
+
+        /// <summary>
+        /// One element that defines the type of the action
+        /// </summary>
+        public ActionType type;
+
+        /// <summary>
+        /// Duration of delay in second before executing the action
+        /// </summary>
+        public float delay;
+
+        /// <summary>
+        /// Determine the activation status of somes nodes
+        /// </summary>
+        public ActivationStatus activationStatus;
+
+        /// <summary>
+        /// Indices of the nodes in the nodes array to set the activation status
+        /// </summary>
+        public int[] nodes;
+
+        /// <summary>
+        /// Transform matrix to apply to the nodes
+        /// </summary>
+        public Matrix4x4 transform;
+
+        /// <summary>
+        /// Index of the animation in the animations array to be considered
+        /// </summary>
+        public int animation;
+
+        /// <summary>
+        /// One element that defines the control of the animation
+        /// </summary>
+        public AnimationControl animationControl;
+
+        /// <summary>
+        /// Index of the media in the MPEG media array to be considered
+        /// </summary>
+        public int media;
+
+        /// <summary>
+        /// Describe the user input related to the manipulation action.
+        /// The format shall follow the OpenXR input path description. An example
+        /// is "/user/hand/left/aim/pose"
+        /// </summary>
+        public string userInputDescription;
+
+        /// <summary>
+        /// On element that defines the control of the media
+        /// </summary>
+        public MediaControl mediaControl;
+
+        /// <summary>
+        /// One element that defines the action manipulate type
+        /// </summary>
+        public ManipulateActionType manipulateActionType;
+
+        /// <summary>
+        /// xyz coordinates of the axis used for rotation and sliding. 
+        /// Relative to the local space created by the USER_INPUT trigger activation
+        /// </summary>
+        public Vector3 axis;
+
+        /// <summary>
+        /// Index of the material in the materials array to apply to the nodes
+        /// </summary>
+        public int material;
+
+        /// <summary>
+        /// List of haptic action nodes
+        /// </summary>
+        public HapticActionNode[] hapticActionNodes;
+
+        /// <summary>
+        /// The avatarAction is a URN that uniquely identifies the avatar action.
+        /// </summary>
+        public string avatarAction;
+
+        internal void GltfSerialize(JsonWriter writer)
+        {
+            writer.AddObject();
+            writer.Close();
+        }
+    }
+
+    /// <summary>
+    /// A Behavior is composed of a pair of triggers and actions
+    /// </summary>
+    [Serializable]
+    public class Behavior
+    {
+        public enum ActionsControl
+        {
+            /// <summary>
+            /// Each defined action is executed sequentially in the order of the actions array
+            /// </summary>
+            SEQUENTIAL = 0,
+
+            /// <summary>
+            /// The defined actions are executed concurrently
+            /// </summary>
+            PARALLEL = 1
+        }
+
+        /// <summary>
+        /// Indices of the triggers in the triggers array considered for this behavior
+        /// </summary>
+        public int[] triggers;
+
+        /// <summary>
+        /// Indices of the actions in the actions array considered for this behavior
+        /// </summary>
+        public int[] actions;
+
+        /// Set of logical operations to apply to the triggers
+        public string triggersCombinationControl;
+
+        /// <summary>
+        /// Indicates when the combination of the triggers shall 
+        /// be activated for launching actions.
+        /// </summary>
+        public TriggerActivationControl triggersActivationControl;
+
+        /// <summary>
+        /// Index Defines the way to execute the defined actions
+        /// </summary>
+        public ActionsControl actionsControl;
+
+        /// <summary>
+        /// Weight associated to the behavior. Used to select 
+        /// a behavior when several behaviors are active at same time for one node
+        /// </summary>
+        public int priority;
+
+        /// <summary>
+        /// Index of the action in the actions array to be executed if the behavior
+        /// is still on-going and is no more defined in a newly received scene update
+        /// </summary>
+        public int? interruptAction;
+
+        internal void GltfSerialize(JsonWriter writer)
+        {
+            writer.AddObject();
+            writer.AddArray("triggers");
+
+            foreach (int tr in triggers)
+            {
+                writer.AddProperty($"{tr}");
+            }
+
+            writer.CloseArray();
+            writer.AddArray("actions");
+            foreach (int act in actions)
+            {
+                writer.AddProperty($"{act}");
+            }
+            writer.CloseArray();
+            writer.AddProperty("triggersCombinationControl", triggersCombinationControl);
+            writer.AddProperty("triggersActivationControl", triggersActivationControl);
+            writer.AddProperty("actionsControl", actionsControl);
+            writer.Close();
+        }
+    }
+
+}

--- a/Runtime/Scripts/Schema/MpegSceneInteractivity.cs.meta
+++ b/Runtime/Scripts/Schema/MpegSceneInteractivity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 065f88bc4a6ad5746b5bf373b90fc3c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Schema/Node.cs
+++ b/Runtime/Scripts/Schema/Node.cs
@@ -132,7 +132,8 @@ namespace GLTFast.Schema {
         public MeshGpuInstancing? EXT_mesh_gpu_instancing;
         /// <inheritdoc cref="LightsPunctual"/>
         public NodeLightsPunctual? KHR_lights_punctual;
-
+        /// <inheritdoc cref="MPEG_node_interactivity"/>
+        public MpegNodeInteractivity? MPEG_node_interactivity;
 
         // ReSharper restore InconsistentNaming
         internal void GltfSerialize(JsonWriter writer) {
@@ -149,6 +150,11 @@ namespace GLTFast.Schema {
             {
                 writer.AddProperty("MPEG_audio_spatial");
                 MPEG_audio_spatial.GltfSerialize(writer);
+            }
+            if(MPEG_node_interactivity != null)
+            {
+                writer.AddProperty("MPEG_node_interactivity");
+                MPEG_node_interactivity.GltfSerialize(writer);
             }
             writer.Close();
         }

--- a/Runtime/Scripts/Schema/RootExtension.cs
+++ b/Runtime/Scripts/Schema/RootExtension.cs
@@ -27,6 +27,9 @@ namespace GLTFast.Schema {
         // MPEG_media extension
         public MpegMediaExtension MPEG_media;
 
+        // MPEG_scene_interactivity extension
+        public MpegSceneInteractivity MPEG_scene_interactivity;
+
         internal void GltfSerialize(JsonWriter writer) {
             writer.AddObject();
             if(KHR_lights_punctual!=null) {
@@ -37,6 +40,11 @@ namespace GLTFast.Schema {
             {
                 writer.AddProperty("MPEG_media");
                 MPEG_media.GltfSerialize(writer);
+            }
+            if(MPEG_scene_interactivity != null)
+            {
+                writer.AddProperty("MPEG_scene_interactivity");
+                MPEG_scene_interactivity.GltfSerialize(writer);
             }
             writer.Close();
         }

--- a/Runtime/Scripts/Schema/Scene.cs
+++ b/Runtime/Scripts/Schema/Scene.cs
@@ -25,11 +25,40 @@ namespace GLTFast.Schema {
         /// The indices of all root nodes
         /// </summary>
         public uint[] nodes;
-        
+
+        /// <inheritdoc cref="SceneExtensions"/>
+        public SceneExtensions extensions = new SceneExtensions();
+
         internal void GltfSerialize(JsonWriter writer) {
             writer.AddObject();
             GltfSerializeRoot(writer);
             writer.AddArrayProperty("nodes",nodes);
+
+            if(extensions != null)
+            {
+                writer.AddProperty("extensions");
+                extensions.GltfSerialize(writer);
+            }
+            writer.Close();
+        }
+    }
+
+    /// <summary>
+    /// Scene extensions
+    /// </summary>
+    [System.Serializable]
+    public class SceneExtensions
+    {
+        public MpegSceneInteractivity MPEG_scene_interactivity;
+
+        internal void GltfSerialize(JsonWriter writer)
+        {
+            writer.AddObject();
+            if (MPEG_scene_interactivity != null)
+            {
+                writer.AddProperty("MPEG_scene_interactivity");
+                MPEG_scene_interactivity.GltfSerialize(writer);
+            }
             writer.Close();
         }
     }

--- a/Runtime/Scripts/TimeUtils.cs
+++ b/Runtime/Scripts/TimeUtils.cs
@@ -1,0 +1,47 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System.Collections;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Launch timers within Unity coroutines to execute delayed actions
+    /// </summary>
+    public class TimeUtils : MonoBehaviour
+    {
+        public static TimeUtils instance => m_Instance;
+        private static TimeUtils m_Instance;
+
+        private void Awake()
+        {
+            if(m_Instance != null)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            m_Instance = this;
+        }
+
+        public void StartTimer(float _delay, System.Action _action)
+        {
+            StartCoroutine(IStartTimer(_delay, _action));
+        }
+
+        private IEnumerator IStartTimer(float _delay, System.Action _action)
+        {
+            yield return new WaitForSeconds(_delay);
+            _action();
+        }
+    }
+}

--- a/Runtime/Scripts/TimeUtils.cs.meta
+++ b/Runtime/Scripts/TimeUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed3006ccedd024e4daa5f6ff8535d82c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/UserInputNodeTrigger.cs
+++ b/Runtime/Scripts/UserInputNodeTrigger.cs
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GLTFast 
+{   
+    /// <summary>
+    /// Represent the user input trigger at the node level
+    /// </summary>
+    public class UserInputNodeTrigger : MonoBehaviour
+    {
+        private string[] m_UserInputParameters;
+
+        public List<string> keys = new List<string>();
+        public List<string> values = new List<string>();
+
+        public void Init(string[] _userInputParameters)
+        {
+            // Format of the user input parameters should be the following
+            // key=value;
+
+            // So for each input parameter we need to split the key and the value 
+            // with the '=' separator
+            // Cache the value for convenience
+            m_UserInputParameters = _userInputParameters;
+            for(int i = 0; i < _userInputParameters.Length; i++)
+            {
+                string[] _keyValue = _userInputParameters[i].Split('=');
+                
+                if(_keyValue.Length > 2)
+                {
+                    throw new System.Exception("Error whille parsing user input parameters at " +
+                        "the user input node trigger level. Key and value should follow the format Key=Value");
+                }
+
+                for (int j = 0; j < _keyValue.Length - 1; j++)
+                {
+                    keys.Add(_keyValue[j]);
+                    values.Add(_keyValue[j + 1]);
+                }
+            }
+        }
+
+        public bool Resolve()
+        {
+            // TODO The application should implement this function
+            return true;
+        }
+    }
+}

--- a/Runtime/Scripts/UserInputNodeTrigger.cs.meta
+++ b/Runtime/Scripts/UserInputNodeTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fac4bf82857202c4d8f963c76a8a51cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/UserInputSceneTrigger.cs
+++ b/Runtime/Scripts/UserInputSceneTrigger.cs
@@ -1,0 +1,142 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+using System.Text;
+using System;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using System.Collections.Generic;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Represent the user input trigger at the scene level
+    /// </summary>
+    public class UserInputSceneTrigger : MonoBehaviour, IMpegInteractivityTrigger
+    {
+        // Require the last unity package to work
+#if USE_NEW_INPUT_SYSTEM
+        public InputAction inputAction => m_InputAction;
+        private InputAction m_InputAction;
+#else
+        // Not implemented
+#endif
+        private GameObject[] m_Targets;
+        private bool m_IsPerformed;
+        private List<UserInputNodeTrigger> m_NodeTriggers = new List<UserInputNodeTrigger>();
+
+        private void OnInputCanceled(InputAction.CallbackContext context)
+        {
+            m_IsPerformed = false;
+        }
+
+        private void OnInputPerformed(InputAction.CallbackContext context)
+        {
+            m_IsPerformed = true;
+            if(m_NodeTriggers.Count > 0)
+            {
+                for (int i = 0; i < m_NodeTriggers.Count; i++) 
+                {
+                    // Does the node triggers resolve this input compared
+                    // to the given parameters ?
+                    if(!m_NodeTriggers[i].Resolve())
+                    {
+                        m_IsPerformed = false;
+                    }
+                }
+            }
+        }
+
+        public bool MeetConditions()
+        {
+            return m_IsPerformed;
+        }
+
+        public void Init(Trigger trigger)
+        {
+            string binding = GetBindingFromUserInputDescription(trigger.userInputDescription);
+#if USE_NEW_INPUT_SYSTEM
+
+            m_InputAction = new InputAction(trigger.userInputDescription, binding: binding);
+
+            m_InputAction.performed += OnInputPerformed;
+            m_InputAction.canceled += OnInputCanceled;
+            m_InputAction.Enable();
+#endif
+            if(trigger.nodes != null)
+            {
+                m_Targets = VirtualSceneGraph.GetGameObjectsFromIndexes(trigger.nodes);
+                for(int i = 0; i < trigger.nodes.Length; i++)
+                {
+                    Node _node = VirtualSceneGraph.GetNodeFromNodeIndex(trigger.nodes[i]);
+                    if(_node.extensions.MPEG_node_interactivity != null)
+                    {
+                        if(_node.extensions.MPEG_node_interactivity.triggers[i].type == TriggerType.TRIGGER_USER_INPUT)
+                        {
+                            UserInputNodeTrigger _nodeTrigger 
+                                = m_Targets[i].AddComponent<UserInputNodeTrigger>();
+
+                            _nodeTrigger.Init(_node.extensions.MPEG_node_interactivity.triggers[i].userInputParameters);
+                        }
+                    }
+                }
+            }
+        }
+
+        public static string GetBindingFromUserInputDescription(string description)
+        {
+            if(string.IsNullOrEmpty(description)) 
+            {
+                throw new Exception("Trying to get binding from description, but it's null");
+            }
+
+            StringBuilder builder = new StringBuilder();
+            string[] userInputDesc = description.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            switch (userInputDesc[0].ToLowerInvariant())
+            {
+                case "mouse":
+                    builder.Append("<Mouse>");
+                    builder.Append("/");
+                    break;
+
+                case "keyboard":
+                    builder.Append("<Keyboard>");
+                    builder.Append("/");
+                    break;
+
+                case "touchscreen":
+                    builder.Append("<Touchscreen>");
+                    builder.Append("/");
+                    builder.Append("Press");
+                    break;
+            }
+
+            builder.Append(userInputDesc[1]);
+
+            string input = userInputDesc[1].ToLowerInvariant();
+
+            switch (input)
+            {
+                case "leftbutton":
+                    {
+                        break;
+                    }
+                case "position":
+                    {
+                        break;
+                    }
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/Runtime/Scripts/UserInputSceneTrigger.cs
+++ b/Runtime/Scripts/UserInputSceneTrigger.cs
@@ -24,12 +24,8 @@ namespace GLTFast
     public class UserInputSceneTrigger : MonoBehaviour, IMpegInteractivityTrigger
     {
         // Require the last unity package to work
-#if USE_NEW_INPUT_SYSTEM
         public InputAction inputAction => m_InputAction;
         private InputAction m_InputAction;
-#else
-        // Not implemented
-#endif
         private GameObject[] m_Targets;
         private bool m_IsPerformed;
         private List<UserInputNodeTrigger> m_NodeTriggers = new List<UserInputNodeTrigger>();
@@ -64,14 +60,11 @@ namespace GLTFast
         public void Init(Trigger trigger)
         {
             string binding = GetBindingFromUserInputDescription(trigger.userInputDescription);
-#if USE_NEW_INPUT_SYSTEM
 
             m_InputAction = new InputAction(trigger.userInputDescription, binding: binding);
-
             m_InputAction.performed += OnInputPerformed;
             m_InputAction.canceled += OnInputCanceled;
             m_InputAction.Enable();
-#endif
             if(trigger.nodes != null)
             {
                 m_Targets = VirtualSceneGraph.GetGameObjectsFromIndexes(trigger.nodes);

--- a/Runtime/Scripts/UserInputSceneTrigger.cs.meta
+++ b/Runtime/Scripts/UserInputSceneTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2ce1500939b35f488db6efde0dcc6d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/VirtualSceneGraph.cs
+++ b/Runtime/Scripts/VirtualSceneGraph.cs
@@ -1,0 +1,279 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Helper class that maps glTF entities to Unity ones
+    /// </summary>
+    public static class VirtualSceneGraph
+    {
+        private static CustomDictionary<int, GameObject> m_NodeGameObject
+            = new CustomDictionary<int, GameObject>();
+
+        private static CustomDictionary<int, UnityEngine.Mesh> m_MeshIndexMesh
+            = new CustomDictionary<int, UnityEngine.Mesh>();
+
+        private static CustomDictionary<int, UnityEngine.Material> m_MaterialIndexMaterial
+            = new CustomDictionary<int, UnityEngine.Material>();
+
+        private static CustomDictionary<int, UnityEngine.Texture2D> m_TextureIndexTexture
+            = new CustomDictionary<int, UnityEngine.Texture2D>();
+
+        private static Transform sceneTransform;
+        private static CustomDictionary<int, AnimationClip> m_AnimationIndexAnimationClip
+            = new CustomDictionary<int, AnimationClip>();
+
+        private static CustomDictionary<string, Animation> m_AnimationIndexAnimation
+            = new CustomDictionary<string, Animation>();
+
+        private static CustomDictionary<int, UnityEngine.Camera> m_CameraIndexCamera
+            = new CustomDictionary<int, UnityEngine.Camera>();
+
+        private static CustomDictionary<int, IMpegInteractivityBehavior> m_BehaviorIndexBehavior
+            = new CustomDictionary<int, IMpegInteractivityBehavior>();
+
+        private static CustomDictionary<int, IMpegInteractivityTrigger> m_TriggerIndexTrigger
+            = new CustomDictionary<int, IMpegInteractivityTrigger>();
+
+        private static CustomDictionary<int, IMpegInteractivityAction> m_ActionIndexAction
+            = new CustomDictionary<int, IMpegInteractivityAction>();
+
+        public static Root root;
+
+        public static void SetRoot(Root _root)
+        {
+            root = _root;
+        }
+
+        // Nodes and game objects
+        public static void AssignGameObjectToNode(int nodeIndex, GameObject item, int node)
+        {
+            m_NodeGameObject.Add(nodeIndex, node, item);
+        }
+
+        public static Node GetNodeFromNodeIndex(int node)
+        {
+            return root.nodes[node];
+        }
+
+        public static Node GetNodeFromGameObject(GameObject go)
+        {
+            int nodeIndex = GetNodeIndexFromGameObject(go);
+            return root.nodes[nodeIndex];
+        }
+
+        public static int GetNodeIndexFromGameObject(GameObject go)
+        {
+            return m_NodeGameObject.GetKeyFromValue(go);
+        }
+
+        public static GameObject GetGameObjectFromIndex(int node)
+        {
+            return m_NodeGameObject.GetValueFromKey(node);
+        }
+
+        public static int GetNodeCount()
+        {
+            return m_NodeGameObject.values.Count;
+        }
+
+        public static GameObject[] GetGameObjectsFromIndexes(int[] nodes)
+        {
+            GameObject[] targets = new GameObject[nodes.Length];
+            for (int i = 0; i < nodes.Length; i++)
+            {
+                targets[i] = GetGameObjectFromIndex(nodes[i]);
+            }
+            return targets;
+        }
+
+        // Mesh indexes and meshes
+
+        public static void AssignMeshToMeshIndex(int meshIndex, UnityEngine.Mesh mesh)
+        {
+            m_MeshIndexMesh.Add(meshIndex, meshIndex, mesh);
+        }
+
+        public static UnityEngine.Mesh GetMeshFromIndex(int mesh_index)
+        {
+            return m_MeshIndexMesh.GetValueFromKey(mesh_index);
+        }
+
+        // Material indexes and materials
+        public static void AssignMaterialIndexToMaterial(int materialIndex, UnityEngine.Material mat)
+        {
+            m_MaterialIndexMaterial.Add(materialIndex, materialIndex, mat);
+        }
+
+        public static UnityEngine.Material GetMaterialFromIndex(int materialIndex)
+        {
+            return m_MaterialIndexMaterial.GetValueFromKey(materialIndex);
+        }
+
+        // Texture indexes and textures
+        public static void AssignTextureIndexToTexture(int textureIndex, UnityEngine.Texture2D tex)
+        {
+            m_TextureIndexTexture.Add(textureIndex, textureIndex, tex);
+        }
+
+        public static UnityEngine.Texture2D GetTextureFromIndex(int textureIndex)
+        {
+            return m_TextureIndexTexture.GetValueFromKey(textureIndex);
+        }
+
+        public static void AssignAnimationIndexToAnimationClip(int animationIndex, AnimationClip animation)
+        {
+            m_AnimationIndexAnimationClip.Add(animationIndex, animationIndex, animation);
+        }
+
+        public static void AssignSceneTransform(Transform _sceneTransform)
+        {
+            sceneTransform = _sceneTransform;
+        }
+
+        public static Transform GetSceneTransform()
+        {
+            return sceneTransform;
+        }
+
+        public static AnimationClip GetAnimationClipFromIndex(int animationIndex)
+        {
+            return m_AnimationIndexAnimationClip.GetValueFromKey(animationIndex);
+        }
+
+        public static void AssignAnimationIndexToAnimation(int animationIndex, string clipIndex, Animation animation)
+        {
+            m_AnimationIndexAnimation.Add(animationIndex, clipIndex, animation);
+        }
+
+        public static Animation[] GetAllAnimations()
+        {
+            return m_AnimationIndexAnimation.GetAllValues();
+        }
+
+        public static Animation GetAnimationFromClipIndex(int animationIndex)
+        {
+            AnimationClip clip = GetAnimationClipFromIndex(animationIndex);
+            Animation anim = m_AnimationIndexAnimation.GetValueFromKey(clip.name);
+            return anim;
+        }
+        public static void AssignCameraIndexToCamera(int cameraNode, UnityEngine.Camera camera)
+        {
+            m_CameraIndexCamera.Add(cameraNode, cameraNode, camera);
+        }
+        public static UnityEngine.Camera GetCameraByIndex(int cameraNode)
+        {
+            return m_CameraIndexCamera.GetValueFromKey(cameraNode);
+        }
+
+        public static IMpegInteractivityBehavior GetBehaviorByIndex(int index)
+        {
+            return m_BehaviorIndexBehavior.GetValueFromKey(index);
+        }
+
+        public static void AssignBehaviorIndexToBehavior(IMpegInteractivityBehavior bhv, int index)
+        {
+            m_BehaviorIndexBehavior.Add(index, index, bhv);
+        }
+
+        public static IMpegInteractivityBehavior[] GetBehaviors()
+        {
+            return m_BehaviorIndexBehavior.values.ToArray();
+        }
+
+        internal static void AssignTriggerToIndex(IMpegInteractivityTrigger trigger, int index)
+        {
+            m_TriggerIndexTrigger.Add(index, index, trigger);
+        }
+
+        public static IMpegInteractivityTrigger GetTriggerFromIndex(int index)
+        {
+            return m_TriggerIndexTrigger.GetValueFromKey(index);
+        }
+
+        internal static void AssignActionToIndex(IMpegInteractivityAction action, int index)
+        {
+            m_ActionIndexAction.Add(index, index, action);
+        }
+
+        public static IMpegInteractivityAction GetActionFromIndex(int index)
+        {
+            return m_ActionIndexAction.GetValueFromKey(index);
+        }
+
+        public static IMpegInteractivityAction[] GetActions()
+        {
+            return m_ActionIndexAction.GetAllValues();
+        }
+    }
+
+    public class CustomDictionary<T, U>
+    {
+        // Store the index of each scene description entities (considered as an ID)
+        public List<int> indexes;
+
+        // Store the scene description entities
+        public List<T> keys;
+
+        // Store the game engine entities
+        public List<U> values;
+
+        public CustomDictionary()
+        {
+            indexes = new List<int>();
+            keys = new List<T>();
+            values = new List<U>();
+        }
+
+        public void Remove(int index)
+        {
+            // Remove index, keys and value from the list
+            indexes.RemoveAt(index);
+            keys.RemoveAt(index);
+            values.RemoveAt(index);
+        }
+
+        public void Add(int index, T key, U value)
+        {
+            indexes.Add(index);
+            keys.Add(key);
+            values.Add(value);
+        }
+
+        internal T GetKeyFromValue(U item)
+        {
+            int index = values.IndexOf(item);
+            return keys[index];
+        }
+
+        internal U GetValueFromKey(T item)
+        {
+            int index = keys.IndexOf(item);
+            if(index == -1)
+            {
+                throw new ArgumentOutOfRangeException($"Failed getting value from key: {item}");
+            }
+            return values[index];
+        }
+
+        internal U[] GetAllValues()
+        {
+            return values.ToArray();
+        }
+    }
+}

--- a/Runtime/Scripts/VirtualSceneGraph.cs.meta
+++ b/Runtime/Scripts/VirtualSceneGraph.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c04a5818c7eef0459c89669ab4c06ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/VisibilityNodeTrigger.cs
+++ b/Runtime/Scripts/VisibilityNodeTrigger.cs
@@ -1,0 +1,315 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Represent the visibility trigger at the node level
+    /// </summary>
+    public class VisibilityNodeTrigger : MonoBehaviour
+    {
+        private bool m_AllowsPartialOcclusion;
+        private Renderer[] m_Target;
+        private UnityEngine.Material[] m_TargetMaterials;
+        private UnityEngine.Mesh m_Mesh;
+        private Renderer m_CurrentRenderer;
+        private UnityEngine.Material m_CurrentMaterial;
+
+        // shaders
+        public Shader depthShader = null;
+        public Shader visibilityShader = null;
+
+        // store the number of visible pixels related to the affected node
+        private ComputeBuffer m_VisiblePixelsBuffer = null;
+        private List<Int32> m_ResetVisiblePixelsBuffer = new List<Int32>();
+
+        // camera used for the depth and visibility computation
+        private UnityEngine.Camera m_ComputeCamera;
+
+        // store the scene depth texture
+        private RenderTexture m_SceneDepthTexture = null;
+
+        // visibility material related to the visibilityShader
+        private UnityEngine.Material m_VisibilityMaterial = null;
+
+        // bias used for the visibility computation
+        private float m_VisibilityBias = 0.01f;
+
+        internal void InitSceneAndNodeLevelExtension(MpegNodeInteractivity.Trigger trigger)
+        {
+            m_AllowsPartialOcclusion = trigger.allowsPartialOcclusion;
+
+            m_Target = new Renderer[trigger.nodes.Length];
+            m_TargetMaterials = new UnityEngine.Material[trigger.nodes.Length];
+
+            for (int i = 0; i < m_Target.Length; i++)
+            {
+                GameObject _go = VirtualSceneGraph.GetGameObjectFromIndex(trigger.nodes[i]);
+                m_Target[i] = _go.GetComponent<Renderer>();
+                m_TargetMaterials[i] = m_Target[i].sharedMaterial;
+            }
+
+            m_CurrentRenderer = GetComponent<Renderer>();
+            m_CurrentMaterial = m_CurrentRenderer.sharedMaterial;
+            InitializeNodeTrigger();
+        }
+
+        private void InitializeNodeTrigger()
+        {
+            m_ComputeCamera = new GameObject("ComputeCam").AddComponent<UnityEngine.Camera>();
+            m_ComputeCamera.enabled = false;
+            // Add elements to handle visibility of this particular node
+
+            // create the _visiblePixelsBuffer
+            if (m_VisiblePixelsBuffer == null)
+            {
+                m_VisiblePixelsBuffer = new ComputeBuffer(2, sizeof(Int32)); // store (maxVisible, visible) nb of pixels
+                Graphics.SetRandomWriteTarget(1, m_VisiblePixelsBuffer, true);
+                m_ResetVisiblePixelsBuffer.Clear();
+                m_ResetVisiblePixelsBuffer.Add(0);
+                m_ResetVisiblePixelsBuffer.Add(0);
+            }
+
+            depthShader = Shader.Find("InterDigital/depthShader");
+            visibilityShader = Shader.Find("InterDigital/visibilityComputationShader");
+
+            // create the _visibilityMaterial
+            if (m_VisibilityMaterial == null)
+            {
+                m_VisibilityMaterial = new UnityEngine.Material(visibilityShader);
+            }
+        }
+
+        internal void InitSceneLevelExtension(Trigger trigger)
+        {
+            m_CurrentRenderer = GetComponent<Renderer>();
+            m_CurrentMaterial = m_CurrentRenderer.sharedMaterial;
+            InitializeNodeTrigger();
+        }
+
+        private void GenerateSceneDepthMap(UnityEngine.Camera _camera)
+        {
+            // copy the visibilityCamera parameters to the _computeCamera
+            m_ComputeCamera.CopyFrom(_camera);
+
+            // modify the _computeCamera parameters to render depth only
+            DepthTextureMode initialCameraDepthTextureMode = m_ComputeCamera.depthTextureMode;
+            m_ComputeCamera.depthTextureMode = DepthTextureMode.None;
+            Color initialCameraBackgroundColor = m_ComputeCamera.backgroundColor;
+            m_ComputeCamera.backgroundColor = Color.white;
+            CameraClearFlags initialCameraClearFlags = m_ComputeCamera.clearFlags;
+            m_ComputeCamera.clearFlags = CameraClearFlags.SolidColor;
+
+            // render the depth with the related depth replacement shader
+            m_ComputeCamera.SetReplacementShader(depthShader, "RenderType");
+            m_ComputeCamera.targetTexture = m_SceneDepthTexture;
+            m_ComputeCamera.Render();
+            m_ComputeCamera.targetTexture = null;
+            m_ComputeCamera.ResetReplacementShader();
+
+            // set the initial inputCamera parameters
+            m_ComputeCamera.clearFlags = initialCameraClearFlags;
+            m_ComputeCamera.backgroundColor = initialCameraBackgroundColor;
+            m_ComputeCamera.depthTextureMode = initialCameraDepthTextureMode;
+
+            // Show depth
+
+            //string debugSceneDepthMapFileName = Path.Combine("C:/Temp/", "sceneDepthMap.png");
+            //RenderTexture.active = m_SceneDepthTexture;
+
+            //Texture2D sceneDepthMap = new Texture2D(m_ComputeCamera.pixelWidth, m_ComputeCamera.pixelHeight, TextureFormat.RFloat, false);
+            //sceneDepthMap.ReadPixels(new Rect(0.0f, 0.0f, m_ComputeCamera.pixelWidth, m_ComputeCamera.pixelHeight), 0, 0);
+
+            //Texture2D pngSceneDepthMap = new Texture2D(m_ComputeCamera.pixelWidth, m_ComputeCamera.pixelHeight, TextureFormat.RGB24, false);
+
+            //// not optimized at all !!
+            //for (int i = 0; i < m_ComputeCamera.pixelWidth; ++i)
+            //{
+            //    for (int j = 0; j < m_ComputeCamera.pixelHeight; ++j)
+            //    {
+            //        float greyLevel = sceneDepthMap.GetPixel(i, j).r * 4.0f;
+            //        Color col = new Color(greyLevel, greyLevel, greyLevel);
+            //        pngSceneDepthMap.SetPixel(i, j, col);
+            //    }
+            //}
+
+            //byte[] bytesSceneDepthMap = pngSceneDepthMap.EncodeToPNG();
+            //File.WriteAllBytes(debugSceneDepthMapFileName, bytesSceneDepthMap);
+            //RenderTexture.active = null;
+        }
+
+
+        private bool EvaluateVisibility(Renderer _rd, UnityEngine.Material _previous, UnityEngine.Camera camera)
+        {
+            m_ComputeCamera.enabled=true;
+
+            // Set a temporary material to the renderer for the computation
+            _rd.sharedMaterial = m_VisibilityMaterial;
+            GenerateSceneDepthMap(camera);
+            int _value = ComputeVisibility(_rd);
+            _rd.sharedMaterial = _previous;
+            m_ComputeCamera.enabled=false;
+
+            // Either fully occluded(0), fully visible(1) or partialy visible(2)
+            bool _result = m_AllowsPartialOcclusion ? (_value == 1 || _value == 2) : _value != 0 && _value == 1;
+            return _result;
+        }
+
+        private int ComputeVisibility(Renderer _rd)
+        {
+            // check the position of the affected node with respect to the camera frustrum
+            if(_rd == null)
+            {
+                Debug.LogError("Renderer is null");
+                return 0;
+            }
+
+            // get the AABB of the affected node
+            Bounds bbox = _rd.bounds;
+            Vector3 bboxCenter = bbox.center;
+            Vector3 bboxExtents = bbox.extents;
+
+            // get the 6 camera frustrum planes
+            Plane[] cameraFrustrumPlanes = GeometryUtility.CalculateFrustumPlanes(m_ComputeCamera);
+
+            bool intersect = false;
+
+            for (int i = 0; i < 6; ++i) // for each of the camera frustrum plane
+            {
+                // get the normal vector of the current plane
+                Vector3 planeNormal = cameraFrustrumPlanes[i].normal;
+                Vector3 planeAbsNormal = new Vector3(Mathf.Abs(planeNormal.x), Mathf.Abs(planeNormal.y), Mathf.Abs(planeNormal.z));
+
+                // get the distance of the current plane with respect to the origin
+                float planeDistance = cameraFrustrumPlanes[i].distance;
+
+                float r = bboxExtents.x * planeAbsNormal.x + bboxExtents.y * planeAbsNormal.y + bboxExtents.z * planeAbsNormal.z;
+                float s = planeNormal.x * bboxCenter.x + planeNormal.y * bboxCenter.y + planeNormal.z * bboxCenter.z;
+
+                if (s + r < -planeDistance) // out of the frustrum
+                {
+                    return -1;
+                }
+
+                intersect |= (s - r <= -planeDistance);
+            }
+
+            if (intersect) // partialy in the frustrum -> return partialy visible
+            {
+                return 2;
+            }
+
+            // at this stage, the affected node is fully inside the camera frustrum
+            //    we need now to check if the affected node is partialy or fully occluded by other nodes
+            // reset the indices buffer
+            m_VisiblePixelsBuffer.SetData(m_ResetVisiblePixelsBuffer);
+
+            // create a temporary RenderTexture for the visibility computation
+            RenderTexture tempTex = RenderTexture.GetTemporary(m_ComputeCamera.pixelWidth, m_ComputeCamera.pixelHeight);
+
+            // set the _visibilityMaterial data
+            m_VisibilityMaterial.SetTexture("sceneDepthTexture", m_SceneDepthTexture);
+            m_VisibilityMaterial.SetBuffer("visiblePixelsBuffer", m_VisiblePixelsBuffer);
+            m_VisibilityMaterial.SetMatrix("worldToViewMatrix", m_ComputeCamera.worldToCameraMatrix);
+            m_VisibilityMaterial.SetMatrix("worldToScreenMatrix", m_ComputeCamera.projectionMatrix * m_ComputeCamera.worldToCameraMatrix);
+            m_VisibilityMaterial.SetFloat("visibilityBias", m_VisibilityBias);
+            m_VisibilityMaterial.SetFloat("cameraZFar", m_ComputeCamera.farClipPlane);
+
+            // set the _visibilityMaterial to the mesh renderer of the affectedNode
+            UnityEngine.Material initialMaterial = _rd.sharedMaterial;
+            _rd.sharedMaterial = m_VisibilityMaterial;
+
+            // compute visibility
+            m_ComputeCamera.targetTexture = tempTex;
+            m_ComputeCamera.Render();
+            m_ComputeCamera.targetTexture = null;
+
+
+            // Write visibility image each frame for debug
+            
+            //string debugTextureFileName = Path.Combine("C:/Temp/", "debugVisibility.png");
+            //RenderTexture.active = tempTex;
+            //Texture2D tex = new Texture2D(_computeCamera.pixelWidth, _computeCamera.pixelHeight, TextureFormat.RGB24, true);
+            //tex.ReadPixels(new Rect(0.0f, 0.0f, _computeCamera.pixelWidth, _computeCamera.pixelHeight), 0, 0);
+            //byte[] bytes_reg = tex.EncodeToPNG();
+            //File.WriteAllBytes(debugTextureFileName, bytes_reg);
+            //RenderTexture.active = null;
+
+            // re-set the _visibilityMaterial
+            _rd.sharedMaterial = initialMaterial;
+
+            RenderTexture.ReleaseTemporary(tempTex);
+
+            // retrieve the visiblePixelsBuffer data
+            Int32[] visiblePixelsBufferData = new Int32[2];
+            m_VisiblePixelsBuffer.GetData(visiblePixelsBufferData);
+
+            // Debugging purpose
+            //Debug.Log("maxVisiblePixels = "+ visiblePixelsBufferData[0]);
+            //Debug.Log("visiblePixels = " + visiblePixelsBufferData[1]);
+
+            // returns the related integer value. Either fully occluded (0), fully visible (1) or partialy visible (2)
+            if (visiblePixelsBufferData[1] == 0)
+            {
+                return 0;
+            }
+            else if ((visiblePixelsBufferData[0] - visiblePixelsBufferData[1]) < 3)
+            {
+                return 1;
+            }
+            else
+            {
+                return 2;
+            }
+        }
+
+        public bool IsVisible(UnityEngine.Camera _camera)
+        {
+            m_ComputeCamera.transform.position = _camera.transform.position;
+            m_ComputeCamera.transform.rotation = _camera.transform.rotation;
+
+            // create the _sceneDepthTexture if necessary
+            if (m_SceneDepthTexture == null)
+            {
+                m_SceneDepthTexture = new RenderTexture(_camera.pixelWidth, _camera.pixelHeight, 16, RenderTextureFormat.RFloat);
+                m_SceneDepthTexture.filterMode = FilterMode.Point;
+            }
+
+            // No node extension for this game object
+            if(m_Target == null)
+            {
+                return EvaluateVisibility(m_CurrentRenderer, m_CurrentMaterial, _camera);
+            }
+
+            for (int i = 0; i < m_Target.Length; i++)
+            {
+                bool _result = EvaluateVisibility(m_Target[i], m_TargetMaterials[i], _camera);
+                if(!_result)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private void OnDestroy()
+        {
+            m_VisiblePixelsBuffer.Dispose();
+        }
+    }
+}

--- a/Runtime/Scripts/VisibilityNodeTrigger.cs
+++ b/Runtime/Scripts/VisibilityNodeTrigger.cs
@@ -53,14 +53,36 @@ namespace GLTFast
         {
             m_AllowsPartialOcclusion = trigger.allowsPartialOcclusion;
 
-            m_Target = new Renderer[trigger.nodes.Length];
-            m_TargetMaterials = new UnityEngine.Material[trigger.nodes.Length];
-
-            for (int i = 0; i < m_Target.Length; i++)
+            if(trigger.nodes == null)
             {
-                GameObject _go = VirtualSceneGraph.GetGameObjectFromIndex(trigger.nodes[i]);
-                m_Target[i] = _go.GetComponent<Renderer>();
-                m_TargetMaterials[i] = m_Target[i].sharedMaterial;
+                m_Target = new Renderer[1];
+                m_TargetMaterials = new UnityEngine.Material[1];
+
+                // TODO: Retrieve a gameobject from a mesh index
+                int _meshIndex = trigger.mesh;
+                int _nodesCount = VirtualSceneGraph.GetNodeCount();
+                for(int i = 0; i < _nodesCount; i++)
+                {
+                    Node _n = VirtualSceneGraph.GetNodeFromNodeIndex(i);
+                    if(_n.mesh == _meshIndex)
+                    {
+                        // found
+                        m_Target[0] = VirtualSceneGraph.GetGameObjectFromIndex(i).GetComponent<Renderer>();
+                        m_TargetMaterials[0] = m_Target[0].sharedMaterial;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                m_Target = new Renderer[trigger.nodes.Length];
+                m_TargetMaterials = new UnityEngine.Material[trigger.nodes.Length];
+                for (int i = 0; i < m_Target.Length; i++)
+                {
+                    GameObject _go = VirtualSceneGraph.GetGameObjectFromIndex(trigger.nodes[i]);
+                    m_Target[i] = _go.GetComponent<Renderer>();
+                    m_TargetMaterials[i] = m_Target[i].sharedMaterial;
+                }
             }
 
             m_CurrentRenderer = GetComponent<Renderer>();

--- a/Runtime/Scripts/VisibilityNodeTrigger.cs.meta
+++ b/Runtime/Scripts/VisibilityNodeTrigger.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: a896e646a456f434e8391f84445902f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - depthShader: {fileID: 4800000, guid: a2d06d6181844df47afcb8c29fd73a05, type: 3}
+  - visibilityShader: {fileID: 4800000, guid: da676c633dedf7149a157e05dfa3420c, type: 3}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/VisibilitySceneTrigger.cs
+++ b/Runtime/Scripts/VisibilitySceneTrigger.cs
@@ -1,0 +1,66 @@
+/*
+* Copyright (c) 2023 InterDigital
+* Licensed under the License terms of 5GMAG software (the "License").
+* You may not use this file except in compliance with the License.
+* You may obtain a copy of the License at https://www.5g-mag.com/license .
+* Unless required by applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+using GLTFast.Schema;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Represent the visibility trigger at the scene level
+    /// </summary>
+    public class VisibilitySceneTrigger : MonoBehaviour, IMpegInteractivityTrigger
+    {
+        private UnityEngine.Camera m_Camera;
+        private VisibilityNodeTrigger[] m_Targets;
+
+        public void Init(Trigger trigger)
+        {
+            m_Camera = UnityEngine.Camera.main;// VirtualSceneGraph.GetCameraByIndex(trigger.cameraNode);
+            m_Targets = new VisibilityNodeTrigger[trigger.nodes.Length];
+
+            for(int i = 0; i < trigger.nodes.Length; i++)
+            {
+                GameObject _targetGo = VirtualSceneGraph.GetGameObjectFromIndex(trigger.nodes[i]);
+                VisibilityNodeTrigger _detector = _targetGo.AddComponent<VisibilityNodeTrigger>();
+
+                Node _node = VirtualSceneGraph.GetNodeFromGameObject(_targetGo);
+                if(_node.extensions.MPEG_node_interactivity != null)
+                {
+                    if(_node.extensions.MPEG_node_interactivity.triggers[i].type == TriggerType.TRIGGER_VISIBILITY)
+                    {
+                        _detector.InitSceneAndNodeLevelExtension(
+                            _node.extensions.MPEG_node_interactivity.triggers[i]);
+                    }
+                }
+                else
+                {
+                    _detector.InitSceneLevelExtension(trigger);
+                }
+
+                m_Targets[i] = _detector;
+            }
+        }
+
+        public bool MeetConditions()
+        {
+            bool result = true;
+            for (int i = 0; i < m_Targets.Length; i++)
+            {
+                if (!m_Targets[i].IsVisible(m_Camera))
+                {
+                    return false;
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/Runtime/Scripts/VisibilitySceneTrigger.cs
+++ b/Runtime/Scripts/VisibilitySceneTrigger.cs
@@ -24,7 +24,10 @@ namespace GLTFast
 
         public void Init(Trigger trigger)
         {
-            m_Camera = UnityEngine.Camera.main;// VirtualSceneGraph.GetCameraByIndex(trigger.cameraNode);
+            Node _n = VirtualSceneGraph.GetNodeFromNodeIndex(trigger.cameraNode);
+            int _camIndex = _n.camera;
+
+            m_Camera = VirtualSceneGraph.GetCameraByIndex(_camIndex);
             m_Targets = new VisibilityNodeTrigger[trigger.nodes.Length];
 
             for(int i = 0; i < trigger.nodes.Length; i++)
@@ -33,13 +36,10 @@ namespace GLTFast
                 VisibilityNodeTrigger _detector = _targetGo.AddComponent<VisibilityNodeTrigger>();
 
                 Node _node = VirtualSceneGraph.GetNodeFromGameObject(_targetGo);
-                if(_node.extensions.MPEG_node_interactivity != null)
+                if(_node.extensions.MPEG_node_interactivity != null
+                && _node.extensions.MPEG_node_interactivity.triggers[i].type == TriggerType.TRIGGER_VISIBILITY)
                 {
-                    if(_node.extensions.MPEG_node_interactivity.triggers[i].type == TriggerType.TRIGGER_VISIBILITY)
-                    {
-                        _detector.InitSceneAndNodeLevelExtension(
-                            _node.extensions.MPEG_node_interactivity.triggers[i]);
-                    }
+                    _detector.InitSceneAndNodeLevelExtension(_node.extensions.MPEG_node_interactivity.triggers[i]);
                 }
                 else
                 {

--- a/Runtime/Scripts/VisibilitySceneTrigger.cs.meta
+++ b/Runtime/Scripts/VisibilitySceneTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e4904ba463dbe049a2b486ee6004bd6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/glTFast.asmdef
+++ b/Runtime/Scripts/glTFast.asmdef
@@ -95,11 +95,6 @@
             "name": "com.unity.shadergraph",
             "expression": "12",
             "define": "UNITY_SHADER_GRAPH_12_OR_NEWER"
-        },
-        {
-            "name": "com.unity.inputsystem",
-            "expression": "1.5",
-            "define": "USE_NEW_INPUT_SYSTEM"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/Scripts/glTFast.asmdef
+++ b/Runtime/Scripts/glTFast.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "glTFast",
+    "rootNamespace": "",
     "references": [
         "Unity.Mathematics",
         "Unity.Burst",
@@ -9,7 +10,8 @@
         "Ktx",
         "Unity.Meshopt.Decompress",
         "Unity.RenderPipelines.Universal.Runtime",
-        "Unity.RenderPipelines.HighDefinition.Runtime"
+        "Unity.RenderPipelines.HighDefinition.Runtime",
+        "Unity.InputSystem"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -93,6 +95,11 @@
             "name": "com.unity.shadergraph",
             "expression": "12",
             "define": "UNITY_SHADER_GRAPH_12_OR_NEWER"
+        },
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "1.5",
+            "define": "USE_NEW_INPUT_SYSTEM"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/Shader/Extensions.meta
+++ b/Runtime/Shader/Extensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e13ec7987bf500040942f9c8c68ef7ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Shader/Extensions/MPEG_Interactivity.meta
+++ b/Runtime/Shader/Extensions/MPEG_Interactivity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a8a4b5fabe7469e47ac861a300deff6f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Shader/Extensions/MPEG_Interactivity/depthShader.shader
+++ b/Runtime/Shader/Extensions/MPEG_Interactivity/depthShader.shader
@@ -1,0 +1,75 @@
+﻿
+Shader "InterDigital/depthShader" {
+	Properties
+	{
+
+	}
+	SubShader
+	{
+		Tags { "RenderType"="Opaque" }
+
+		Pass
+		{
+
+			CGPROGRAM
+			// to use the built-in helper functions
+			#include "UnityCG.cginc"
+			// use "vert" function as the vertex shader
+			#pragma vertex vert
+			// use "frag" function as the pixel (fragment) shader
+			#pragma fragment frag
+
+			#pragma target 3.0
+
+			// vertex shader inputs
+			struct vertIn
+			{
+				float4 vertex : POSITION; // vertex position
+			};
+
+			// vertex shader outputs
+			struct vertOut
+			{
+				float depth       : TEXCOORD0;   // linear depth
+				float4 projPos    : SV_POSITION; // clip space position
+			};
+
+			// fragment shader outputs
+			struct fragOut
+			{
+				float4 color : SV_Target;
+			};
+
+
+			// vertex shader
+			vertOut vert(vertIn v)
+			{
+				vertOut o;
+
+				// computes the linear depth
+				o.depth = COMPUTE_DEPTH_01;
+
+				// calculates the clip space position
+				o.projPos = UnityObjectToClipPos(v.vertex.xyz);
+
+				return o;
+
+			}
+
+
+			// fragment shader
+			fragOut frag(vertOut i)
+			{
+				fragOut o;
+
+				// outputs the linear depth
+				o.color = float4(i.depth, 0.0, 0.0, 0.0);
+				
+				return o;
+
+			}
+			ENDCG
+		}
+	}
+	Fallback off
+}

--- a/Runtime/Shader/Extensions/MPEG_Interactivity/depthShader.shader.meta
+++ b/Runtime/Shader/Extensions/MPEG_Interactivity/depthShader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a2d06d6181844df47afcb8c29fd73a05
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Shader/Extensions/MPEG_Interactivity/visibilityComputationShader.shader
+++ b/Runtime/Shader/Extensions/MPEG_Interactivity/visibilityComputationShader.shader
@@ -1,0 +1,114 @@
+﻿
+Shader "InterDigital/visibilityComputationShader"
+{
+	Properties
+	{
+
+	}
+
+	SubShader
+	{
+		Tags { "RenderType" = "Opaque" }
+
+		// visibility computation
+		Pass
+		{
+			CGPROGRAM
+			// to use the built-in helper functions
+			#include "UnityCG.cginc"
+			// use "vert" function as the vertex shader
+			#pragma vertex vert
+			// use "frag" function as the pixel (fragment) shader
+			#pragma fragment frag
+
+			#pragma target 4.5
+
+			// vertex shader inputs
+			struct vertIn
+			{
+				float4 vertex : POSITION; // vertex position
+			};
+
+			// vertex shader outputs
+			struct vertOut
+			{
+				float3 worldPos : TEXCOORD0; // world position
+				float4 projPos  : SV_POSITION; // clip space position
+			};
+
+			// fragment shader outputs
+			struct fragOut
+			{
+				float4 color : SV_Target;
+			};
+
+
+			// vertex shader
+			vertOut vert(vertIn v)
+			{
+				vertOut o;
+
+				o.worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
+
+				// calculates the clip space position
+				o.projPos = UnityObjectToClipPos(v.vertex.xyz);
+
+				return o;
+
+			}
+
+			sampler2D sceneDepthTexture;
+			RWStructuredBuffer<int> visiblePixelsBuffer : register(u1); // size = 2: (maxVisible, visible) pixels
+			float4x4 worldToViewMatrix;
+			float4x4 worldToScreenMatrix;
+			float visibilityBias;
+			float cameraZFar;
+
+			// fragment shader
+			fragOut frag(vertOut i)
+			{
+				fragOut o;
+
+				// add a visible pixel to the maxVisiblePixels counter
+				InterlockedAdd(visiblePixelsBuffer[0], 1);
+
+				//
+				// check if the pixel is occluded
+				//
+
+				// retrieve the pixel world coordinates
+				float4 worldPosition = float4(i.worldPos, 1.0f);
+
+				// calculates the input world position in the camera screen space
+				float4 screenPosition = mul(worldToScreenMatrix, worldPosition);
+				screenPosition /= screenPosition.w;
+
+				// retrieves the normalized linear eye depth information stored in the camera depth map
+				float4 cameraDepthwMapTextureCoords = float4((screenPosition.xy + 1.0) / 2.0, 0.0f, 0.0f);
+				float eyeCameraDepth = tex2D(sceneDepthTexture, cameraDepthwMapTextureCoords).x;
+				eyeCameraDepth *= cameraZFar;
+				
+				// calculates the input world position in the camera eye space
+				float4 cameraEyePosition = mul(worldToViewMatrix, worldPosition);
+				cameraEyePosition.xyz /= cameraEyePosition.w;
+
+				// checks if the pixel world position is not occluded. The cameraEyePosition.z < 0
+				if (cameraEyePosition.z > (-eyeCameraDepth - visibilityBias))
+				{
+					// is visible
+					InterlockedAdd(visiblePixelsBuffer[1], 1);
+				}
+
+
+				// outputs a red color
+				o.color = float4(1.0, 0.0, 0.0, 1.0);
+
+				return o;
+
+			}
+			ENDCG
+		}
+
+	}
+	Fallback off
+}

--- a/Runtime/Shader/Extensions/MPEG_Interactivity/visibilityComputationShader.shader.meta
+++ b/Runtime/Shader/Extensions/MPEG_Interactivity/visibilityComputationShader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: da676c633dedf7149a157e05dfa3420c
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "com.unity.modules.jsonserialize": "1.0.0",
     "com.unity.modules.unitywebrequest": "1.0.0",
     "com.unity.mathematics": "1.2.6",
+    "com.unity.inputsystem": "1.7.0",
     "com.unity.burst": "1.6.6"
   },
   "type": "library",


### PR DESCRIPTION
This pull request is related to an implementation of the MPEG-SD interactivity extensions.

It requires the import of the package: com.unity.inputsystem (from Unity, via the package manager: Window->Package Manager). It has been tested on the version 1.4.2.

This implementation supports the parsing of a glTF file with the whole interactivity model with the following triggers:

- TRIGGER_COLLISION
- TRIGGER_PROXIMITY
- TRIGGER_USER_INPUT
- TRIGGER_VISIBILITY

And the following actions:

- ACTION_ACTIVATE
- ACTION_TRANSFORM
- ACTION_BLOCK
- ACTION_ANIMATION
- ACTION_MEDIA
- ACTION_MANIPULATE
- ACTION_SET_MATERIAL
- ACTION_HAPTIC
- ACTION_AVATAR

There are a few details of the implementations that are not (yet) released:

- Primitives are supported, but for collision they are using a mesh collider model, they should use a more performant way to process
- The ACTION_USER_INPUT support keyboard and mouse for now, it should also being capable to handle real XR devices
- Pause functionality in the ACTION_ANIMATION is not implemented
- Behavior priority is not implemented
- ACTION_HAPTIC is not implemented
- ACTION_MEDIA is not implemented
- ACTION_AVATAR is not implemented